### PR TITLE
Fix divide by zero panic

### DIFF
--- a/image/qcow2/qcow2.go
+++ b/image/qcow2/qcow2.go
@@ -896,6 +896,10 @@ func (img *Qcow2) ReadAt(p []byte, off int64) (n int, err error) {
 		err = img.errUnreadable
 		return
 	}
+	if img.clusterSize == 0 {
+		err = errors.New("cluster size cannot be 0")
+		return
+	}
 	if len(p) == 0 {
 		return
 	}


### PR DESCRIPTION
Lima triggers a divide-by-zero panic because clustersize is 0.

To test it from Limas side:
1. `git clone https://github.com/lima-vm/lima`
2. `cd lima`
3. `git checkout 6c2bfaa9197b54c8cc5a93707e65e22422b0616c`
4. Create the following unit test: `lima/pkg/nativeimgutil/my_test.go` and run it:

```go
package nativeimgutil

import (
        "os"
        "path/filepath"
        "testing"
)

func TestConvertToRawPoC(t *testing.T) {
        imgData := []byte{81, 70, 73, 251, 49, 56, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 126, 54, 49, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 236, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 17, 0, 0, 0, 0, 0, 0}
        withBacking := false
        size := int64(32)
        srcPath := filepath.Join(t.TempDir(), "src.img")
        destPath := filepath.Join(t.TempDir(), "dest.img")
        err := os.WriteFile(srcPath, imgData, 0o600)
        if err != nil {
                return
        }
        _ = ConvertToRaw(srcPath, destPath, &size, withBacking)
}
```

It results in the following stacktrace:
```
--- FAIL: TestConvertToRawPoC (0.00s)           
panic: runtime error: integer divide by zero [recovered]
        panic: runtime error: integer divide by zero
                                                                                                      
goroutine 19 [running]:                      
testing.tRunner.func1.2({0x6b22e0, 0x926fb0})                                                         
        /usr/lib/go-1.22/src/testing/testing.go:1631 +0x24a   
testing.tRunner.func1()                 
        /usr/lib/go-1.22/src/testing/testing.go:1634 +0x377                    
panic({0x6b22e0?, 0x926fb0?})                                                                         
        /usr/lib/go-1.22/src/runtime/panic.go:770 +0x132
github.com/lima-vm/go-qcow2reader/image/qcow2.(*Qcow2).ReadAt(0xc0001b8420, {0xc000380000, 0x8, 0x100000}, 0x0)
        /home/adam/go/pkg/mod/github.com/lima-vm/go-qcow2reader@v0.1.1/image/qcow2/qcow2.go:911 +0x1ea 
io.(*SectionReader).Read(0xc000192e70, {0xc000380000?, 0x69d920?, 0x1?})
        /usr/lib/go-1.22/src/io/io.go:516 +0x4f                                                       
github.com/cheggaaa/pb/v3.(*Reader).Read(0xc00019a2d0, {0xc000380000?, 0x934fa0?, 0xc00019a2d0?})
        /home/adam/go/pkg/mod/github.com/cheggaaa/pb/v3@v3.1.5/io.go:15 +0x28
github.com/lima-vm/lima/pkg/nativeimgutil.copySparse(0xc0001980e8, {0x75fd60, 0xc00019a2d0}, 0x100000) 
        /tmp/lima/pkg/nativeimgutil/nativeimgutil.go:134 +0xbd                  
github.com/lima-vm/lima/pkg/nativeimgutil.ConvertToRaw({0xc0001d8270, 0x2e}, {0xc0001d8330, 0x2f}, 0xc00002ff08, 0x0)
        /tmp/lima/pkg/nativeimgutil/nativeimgutil.go:79 +0xb05                                                                                                                                               
github.com/lima-vm/lima/pkg/nativeimgutil.TestConvertToRawPoC(0xc0001d0820)                                                                                                                                  
        /tmp/lima/pkg/nativeimgutil/my_test.go:19 +0x22d                                                                                                                                                     
testing.tRunner(0xc0001d0820, 0x70d318)                                                               
        /usr/lib/go-1.22/src/testing/testing.go:1689 +0xfb                                         
created by testing.(*T).Run in goroutine 1                                                            
        /usr/lib/go-1.22/src/testing/testing.go:1742 +0x390
exit status 2                                                                                         
FAIL    github.com/lima-vm/lima/pkg/nativeimgutil       0.016s--- FAIL: TestConvertToRawPoC (0.00s)           
panic: runtime error: integer divide by zero [recovered]
        panic: runtime error: integer divide by zero
                                                                                                      
goroutine 19 [running]:                      
testing.tRunner.func1.2({0x6b22e0, 0x926fb0})                                                         
        /usr/lib/go-1.22/src/testing/testing.go:1631 +0x24a   
testing.tRunner.func1()                 
        /usr/lib/go-1.22/src/testing/testing.go:1634 +0x377                    
panic({0x6b22e0?, 0x926fb0?})                                                                         
        /usr/lib/go-1.22/src/runtime/panic.go:770 +0x132
github.com/lima-vm/go-qcow2reader/image/qcow2.(*Qcow2).ReadAt(0xc0001b8420, {0xc000380000, 0x8, 0x100000}, 0x0)
        /home/adam/go/pkg/mod/github.com/lima-vm/go-qcow2reader@v0.1.1/image/qcow2/qcow2.go:911 +0x1ea 
io.(*SectionReader).Read(0xc000192e70, {0xc000380000?, 0x69d920?, 0x1?})
        /usr/lib/go-1.22/src/io/io.go:516 +0x4f                                                       
github.com/cheggaaa/pb/v3.(*Reader).Read(0xc00019a2d0, {0xc000380000?, 0x934fa0?, 0xc00019a2d0?})
        /home/adam/go/pkg/mod/github.com/cheggaaa/pb/v3@v3.1.5/io.go:15 +0x28
github.com/lima-vm/lima/pkg/nativeimgutil.copySparse(0xc0001980e8, {0x75fd60, 0xc00019a2d0}, 0x100000) 
        /tmp/lima/pkg/nativeimgutil/nativeimgutil.go:134 +0xbd                  
github.com/lima-vm/lima/pkg/nativeimgutil.ConvertToRaw({0xc0001d8270, 0x2e}, {0xc0001d8330, 0x2f}, 0xc00002ff08, 0x0)
        /tmp/lima/pkg/nativeimgutil/nativeimgutil.go:79 +0xb05                                                                                                                                               
github.com/lima-vm/lima/pkg/nativeimgutil.TestConvertToRawPoC(0xc0001d0820)                                                                                                                                  
        /tmp/lima/pkg/nativeimgutil/my_test.go:19 +0x22d                                                                                                                                                     
testing.tRunner(0xc0001d0820, 0x70d318)                                                               
        /usr/lib/go-1.22/src/testing/testing.go:1689 +0xfb                                         
created by testing.(*T).Run in goroutine 1                                                            
        /usr/lib/go-1.22/src/testing/testing.go:1742 +0x390
exit status 2                                                                                         
FAIL    github.com/lima-vm/lima/pkg/nativeimgutil       0.016s
```