### PR TITLE
Add parallel convert

### DIFF
--- a/cmd/go-qcow2reader-example/convert.go
+++ b/cmd/go-qcow2reader-example/convert.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/lima-vm/go-qcow2reader"
+	"github.com/lima-vm/go-qcow2reader/convert"
+	"github.com/lima-vm/go-qcow2reader/log"
+)
+
+func cmdConvert(args []string) error {
+	var (
+		// Required
+		source, target string
+
+		// Options
+		debug   bool
+		options convert.Options
+	)
+
+	fs := flag.NewFlagSet("convert", flag.ExitOnError)
+	fs.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s convert [OPTIONS...] SOURCE TARGET\n", os.Args[0])
+		flag.PrintDefaults()
+	}
+	fs.BoolVar(&debug, "debug", false, "enable printing debug messages")
+	fs.Int64Var(&options.SegmentSize, "segment-size", convert.SegmentSize, "worker segment size in bytes")
+	fs.IntVar(&options.BufferSize, "buffer-size", convert.BufferSize, "buffer size in bytes")
+	fs.IntVar(&options.Workers, "workers", convert.Workers, "number of workers")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if debug {
+		log.SetDebugFunc(logDebug)
+	}
+
+	switch len(fs.Args()) {
+	case 0:
+		return errors.New("no file was specified")
+	case 1:
+		return errors.New("target file is required")
+	case 2:
+		source = fs.Arg(0)
+		target = fs.Arg(1)
+	default:
+		return errors.New("too many files were specified")
+	}
+
+	f, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	img, err := qcow2reader.Open(f)
+	if err != nil {
+		return err
+	}
+	defer img.Close()
+
+	t, err := os.Create(target)
+	if err != nil {
+		return err
+	}
+	defer t.Close()
+
+	if err := t.Truncate(img.Size()); err != nil {
+		return err
+	}
+
+	c, err := convert.New(options)
+	if err != nil {
+		return err
+	}
+	if err := c.Convert(t, img, img.Size()); err != nil {
+		return err
+	}
+
+	if err := t.Sync(); err != nil {
+		return err
+	}
+
+	return t.Close()
+}

--- a/cmd/go-qcow2reader-example/info.go
+++ b/cmd/go-qcow2reader-example/info.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/lima-vm/go-qcow2reader"
+	"github.com/lima-vm/go-qcow2reader/image"
+)
+
+func cmdInfo(args []string) error {
+	var (
+		// Required
+		filename string
+
+		// Options
+		debug bool
+	)
+
+	fs := flag.NewFlagSet("info", flag.ExitOnError)
+	fs.Usage = func() {
+		fmt.Fprintf(fs.Output(), "Usage: %s info [OPTIONS...] FILE\n", os.Args[0])
+		fs.PrintDefaults()
+	}
+	fs.BoolVar(&debug, "debug", false, "enable printing debug messages")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	switch len(fs.Args()) {
+	case 0:
+		return errors.New("no file was specified")
+	case 1:
+		filename = fs.Arg(0)
+	default:
+		return errors.New("too many files specified")
+	}
+
+	f, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	img, err := qcow2reader.Open(f)
+	if err != nil {
+		return err
+	}
+	defer img.Close()
+
+	imgInfo := image.NewImageInfo(img)
+	j, err := json.MarshalIndent(imgInfo, "", "    ")
+	if err != nil {
+		return err
+	}
+	if _, err = fmt.Println(string(j)); err != nil {
+		return err
+	}
+	if err = img.Readable(); err != nil {
+		logWarn(err.Error())
+	}
+
+	return nil
+}

--- a/cmd/go-qcow2reader-example/main.go
+++ b/cmd/go-qcow2reader-example/main.go
@@ -1,25 +1,20 @@
 package main
 
 import (
-	"encoding/json"
-	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"os"
 
 	"github.com/klauspost/compress/zstd"
-	"github.com/lima-vm/go-qcow2reader"
-	"github.com/lima-vm/go-qcow2reader/image"
 	"github.com/lima-vm/go-qcow2reader/image/qcow2"
 	"github.com/lima-vm/go-qcow2reader/log"
 )
 
-func warn(s string) {
+func logWarn(s string) {
 	fmt.Fprintln(os.Stderr, "WARNING: "+s)
 }
 
-func debugPrint(s string) {
+func logDebug(s string) {
 	fmt.Fprintln(os.Stderr, "DEBUG: "+s)
 }
 
@@ -40,82 +35,45 @@ func newZstdDecompressor(r io.Reader) (io.ReadCloser, error) {
 	return &zstdDecompressor{dec}, nil
 }
 
+func usage() {
+	usage := `Usage: %s COMMAND [OPTIONS...]
+
+Available commands:
+  info		show image information
+  read		read image data and print to stdout
+`
+	fmt.Fprintf(os.Stderr, usage, os.Args[0])
+	os.Exit(1)
+}
+
 func main() {
-	log.SetWarnFunc(warn)
+	log.SetWarnFunc(logWarn)
 
 	// zlib (deflate) decompressor is registered by default, but zstd is not.
 	qcow2.SetDecompressor(qcow2.CompressionTypeZstd, newZstdDecompressor)
 
-	if err := xmain(); err != nil {
+	var err error
+
+	var cmd string
+	if len(os.Args) > 1 {
+		cmd = os.Args[1]
+	}
+	var args []string
+	if len(os.Args) > 2 {
+		args = os.Args[2:]
+	}
+
+	switch cmd {
+	case "info":
+		err = cmdInfo(args)
+	case "read":
+		err = cmdRead(args)
+	default:
+		usage()
+	}
+
+	if err != nil {
 		fmt.Fprintln(os.Stderr, "ERROR: "+err.Error())
 		os.Exit(1)
 	}
-}
-
-func xmain() error {
-	flag.Usage = func() {
-		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s [OPTIONS...] FILE\n", os.Args[0])
-		flag.PrintDefaults()
-	}
-	var (
-		debug      bool
-		info       bool
-		bufferSize int
-		offset     int64
-		length     int64
-	)
-	flag.BoolVar(&debug, "debug", false, "enable printing debug messages")
-	flag.BoolVar(&info, "info", false, "print the image info and exit")
-	flag.IntVar(&bufferSize, "buffer", 65536, "buffer size")
-	flag.Int64Var(&offset, "offset", 0, "offset to read")
-	flag.Int64Var(&length, "length", -1, "length to read")
-	flag.Parse()
-	if debug {
-		log.SetDebugFunc(debugPrint)
-	}
-
-	args := flag.Args()
-	switch len(args) {
-	case 0:
-		return errors.New("no file was specified")
-	case 1:
-		// NOP
-	default:
-		return errors.New("too many files were specified")
-	}
-	fName := args[0]
-
-	f, err := os.Open(fName)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	img, err := qcow2reader.Open(f)
-	if err != nil {
-		return err
-	}
-
-	if info {
-		imgInfo := image.NewImageInfo(img)
-		j, err := json.MarshalIndent(imgInfo, "", "    ")
-		if err != nil {
-			return err
-		}
-		if _, err = fmt.Println(string(j)); err != nil {
-			return err
-		}
-		if err = img.Readable(); err != nil {
-			warn(err.Error())
-		}
-		return nil
-	}
-
-	if length < 0 {
-		length = img.Size()
-	}
-	buf := make([]byte, bufferSize)
-	sr := io.NewSectionReader(img, offset, length)
-	_, err = io.CopyBuffer(os.Stdout, sr, buf)
-	return err
 }

--- a/cmd/go-qcow2reader-example/main.go
+++ b/cmd/go-qcow2reader-example/main.go
@@ -41,6 +41,7 @@ func usage() {
 Available commands:
   info		show image information
   read		read image data and print to stdout
+  convert      convert image to raw format
 `
 	fmt.Fprintf(os.Stderr, usage, os.Args[0])
 	os.Exit(1)
@@ -68,6 +69,8 @@ func main() {
 		err = cmdInfo(args)
 	case "read":
 		err = cmdRead(args)
+	case "convert":
+		err = cmdConvert(args)
 	default:
 		usage()
 	}

--- a/cmd/go-qcow2reader-example/read.go
+++ b/cmd/go-qcow2reader-example/read.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/lima-vm/go-qcow2reader"
+	"github.com/lima-vm/go-qcow2reader/log"
+)
+
+func cmdRead(args []string) error {
+	var (
+		// Required
+		filename string
+
+		// Options
+		debug      bool
+		bufferSize int
+		offset     int64
+		length     int64
+	)
+
+	fs := flag.NewFlagSet("read", flag.ExitOnError)
+	fs.Usage = func() {
+		fmt.Fprintf(fs.Output(), "Usage: %s read [OPTIONS...] FILE\n", os.Args[0])
+		flag.PrintDefaults()
+	}
+	fs.BoolVar(&debug, "debug", false, "enable printing debug messages")
+	fs.IntVar(&bufferSize, "buffer-size", 65536, "buffer size")
+	fs.Int64Var(&offset, "offset", 0, "offset to read")
+	fs.Int64Var(&length, "length", -1, "length to read")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if debug {
+		log.SetDebugFunc(logDebug)
+	}
+
+	switch len(fs.Args()) {
+	case 0:
+		return errors.New("no file was specified")
+	case 1:
+		filename = fs.Arg(0)
+	default:
+		return errors.New("too many files were specified")
+	}
+
+	f, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	img, err := qcow2reader.Open(f)
+	if err != nil {
+		return err
+	}
+	defer img.Close()
+
+	if length < 0 {
+		length = img.Size()
+	}
+
+	buf := make([]byte, bufferSize)
+	sr := io.NewSectionReader(img, offset, length)
+	_, err = io.CopyBuffer(os.Stdout, sr, buf)
+
+	return err
+}

--- a/convert/convert.go
+++ b/convert/convert.go
@@ -1,0 +1,195 @@
+package convert
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+)
+
+const BufferSize = 1024 * 1024
+
+// Smaller value may increase the overhead of synchornizing multiple works.
+// Larger value may be less efficient for smaller images. The defualt value
+// gives good results for the lima default Ubuntu image.
+const SegmentSize = 32 * BufferSize
+
+// For best I/O throughput we want to have enough in-flight requests, regardless
+// of number of cores. For best decompression we want to use one worker per
+// core, but too many workers is less effective. The default value gives good
+// results with lima default Ubuntu image.
+const Workers = 8
+
+type Options struct {
+	// SegmentSize in bytes. Must be aligned to BufferSize. If not set, use the
+	// default value (32 MiB).
+	SegmentSize int64
+
+	// BufferSize in bytes. If not set, use the default value (1 MiB).
+	BufferSize int
+
+	// Workers is the number of goroutines copying buffers in parallel. If not set
+	// use the default value (8).
+	Workers int
+}
+
+// Validate validates options and set default values. Returns an error for
+// invalid option values.
+func (o *Options) Validate() error {
+	if o.SegmentSize < 0 {
+		return errors.New("segment size must be positive")
+	}
+	if o.SegmentSize == 0 {
+		o.SegmentSize = SegmentSize
+	}
+
+	if o.BufferSize < 0 {
+		return errors.New("buffer size must be positive")
+	}
+	if o.BufferSize == 0 {
+		o.BufferSize = BufferSize
+	}
+
+	if o.Workers < 0 {
+		return errors.New("number of workers must be positive")
+	}
+	if o.Workers == 0 {
+		o.Workers = Workers
+	}
+
+	// This is not stritcly required, but there is no reason support unaligned
+	// segment size.
+	if o.SegmentSize%int64(o.BufferSize) != 0 {
+		return errors.New("segment size not aligned to buffer size")
+	}
+
+	return nil
+}
+
+type Converter struct {
+	// Read only after starting.
+	size        int64
+	segmentSize int64
+	bufferSize  int
+	workers     int
+
+	// State modified during Convert, protected by the mutex.
+	mutex  sync.Mutex
+	offset int64
+	err    error
+}
+
+// New returns a new converter intialized from options.
+func New(opts Options) (*Converter, error) {
+	if err := opts.Validate(); err != nil {
+		return nil, err
+	}
+	c := &Converter{
+		segmentSize: opts.SegmentSize,
+		bufferSize:  opts.BufferSize,
+		workers:     opts.Workers,
+	}
+	return c, nil
+}
+
+// nextSegment returns the next segment to process and stop flag. The stop flag
+// is true if there is no more work, or if another workers has failed and set
+// the error.
+func (c *Converter) nextSegment() (int64, int64, bool) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if c.offset == c.size || c.err != nil {
+		return 0, 0, true
+	}
+
+	start := c.offset
+	c.offset += c.segmentSize
+	if c.offset > c.size {
+		c.offset = c.size
+	}
+
+	return start, c.offset, false
+}
+
+// setError keeps the first error set. Setting the error signal other workes to
+// abort the operation.
+func (c *Converter) setError(err error) {
+	c.mutex.Lock()
+	if c.err == nil {
+		c.err = err
+	}
+	c.mutex.Unlock()
+}
+
+func (c *Converter) reset(size int64) {
+	c.size = size
+	c.err = nil
+	c.offset = 0
+}
+
+// Convert copy size bytes from io.ReaderAt to io.WriterAt. Unallocated areas or
+// areas full of zeros in the source are keep unallocated in the destination.
+// The destination must be new empty or full of zeroes.
+func (c *Converter) Convert(wa io.WriterAt, ra io.ReaderAt, size int64) error {
+	c.reset(size)
+
+	zero := make([]byte, c.bufferSize)
+	var wg sync.WaitGroup
+
+	for i := 0; i < c.workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			buf := make([]byte, c.bufferSize)
+			for {
+				// Get next segment to copy.
+				start, end, stop := c.nextSegment()
+				if stop {
+					return
+				}
+
+				for start < end {
+					// The last read may be shorter.
+					n := len(buf)
+					if end-start < int64(len(buf)) {
+						n = int(end - start)
+					}
+
+					// Read more data.
+					nr, err := ra.ReadAt(buf[:n], start)
+					if err != nil {
+						if !errors.Is(err, io.EOF) {
+							c.setError(err)
+							return
+						}
+
+						// EOF for the last read of the last segment is expected, but since we
+						// read exactly size bytes, we shoud never get a zero read.
+						if nr == 0 {
+							c.setError(errors.New("unexpected EOF"))
+							return
+						}
+					}
+
+					// If the data is all zeros we skip it to create a hole. Otherwise
+					// write the data.
+					if !bytes.Equal(buf[:nr], zero[:nr]) {
+						if nw, err := wa.WriteAt(buf[:nr], start); err != nil {
+							c.setError(err)
+							return
+						} else if nw != nr {
+							c.setError(fmt.Errorf("read %d, but wrote %d bytes", nr, nw))
+							return
+						}
+					}
+					start += int64(nr)
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+	return c.err
+}

--- a/hack/compare-with-qemu-img.sh
+++ b/hack/compare-with-qemu-img.sh
@@ -11,7 +11,7 @@ name_raw_b="${name_qcow2}.raw_b"
 
 echo "Input file: ${name_qcow2}"
 set -x
-go-qcow2reader-example -info "${name_qcow2}"
+go-qcow2reader-example info "${name_qcow2}"
 set +x
 
 echo "===== Phase 1: full read ====="
@@ -29,9 +29,9 @@ if [ ! -e "${name_raw_a}".sha256 ]; then
 fi
 
 rm -f "${name_raw_b}" "${name_raw_b}.sha256"
-echo "Converting ${name_qcow2} to ${name_raw_b} with go-qcow2reader"
+echo "Converting ${name_qcow2} to ${name_raw_b} with go-qcow2reader read"
 set -x
-go-qcow2reader-example "${name_qcow2}" >"${name_raw_b}"
+go-qcow2reader-example read "${name_qcow2}" >"${name_raw_b}"
 sha256sum "${name_raw_b}" | tee "${name_raw_b}.sha256"
 set +x
 
@@ -54,7 +54,7 @@ for offset in 1 22 333 4444 55555 666666 7777777 88888888; do
 		set +o pipefail
 		expected="$(tail -c "+$((${offset} + 1))" "${name_raw_a}" | head -c "${length}" | sha256sum - | cut -d " " -f 1)"
 		set -o pipefail
-		got="$(go-qcow2reader-example -offset="${offset}" -length="${length}" "${name_qcow2}" | sha256sum - | cut -d " " -f 1)"
+		got="$(go-qcow2reader-example read -offset="${offset}" -length="${length}" "${name_qcow2}" | sha256sum - | cut -d " " -f 1)"
 		set +x
 		echo "Comparing: ${expected} vs ${got}"
 		if [ "${expected}" = "${got}" ]; then

--- a/qcow2reader_test.go
+++ b/qcow2reader_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/lima-vm/go-qcow2reader/convert"
 	"github.com/lima-vm/go-qcow2reader/image"
 	"github.com/lima-vm/go-qcow2reader/image/qcow2"
 )
@@ -24,7 +25,7 @@ const (
 
 // Benchmark completely empty sparse image (0% utilization).  This is the best
 // case when we don't have to read any cluster from storage.
-func BenchmarkRead0p(b *testing.B) {
+func Benchmark0p(b *testing.B) {
 	const size = 256 * MiB
 	base := filepath.Join(b.TempDir(), "image")
 	if err := createTestImage(base, size, 0.0); err != nil {
@@ -35,26 +36,42 @@ func BenchmarkRead0p(b *testing.B) {
 		if err := qemuImgConvert(base, img, qcow2.Type, CompressionTypeNone); err != nil {
 			b.Fatal(err)
 		}
-		resetBenchmark(b, size)
-		for i := 0; i < b.N; i++ {
-			benchmarkRead(b, img)
-		}
+		b.Run("read", func(b *testing.B) {
+			resetBenchmark(b, size)
+			for i := 0; i < b.N; i++ {
+				benchmarkRead(b, img)
+			}
+		})
+		b.Run("convert", func(b *testing.B) {
+			resetBenchmark(b, size)
+			for i := 0; i < b.N; i++ {
+				benchmarkConvert(b, img)
+			}
+		})
 	})
 	b.Run("qcow2 zlib", func(b *testing.B) {
 		img := base + ".zlib.qcow2"
 		if err := qemuImgConvert(base, img, qcow2.Type, qcow2.CompressionTypeZlib); err != nil {
 			b.Fatal(err)
 		}
-		resetBenchmark(b, size)
-		for i := 0; i < b.N; i++ {
-			benchmarkRead(b, img)
-		}
+		b.Run("read", func(b *testing.B) {
+			resetBenchmark(b, size)
+			for i := 0; i < b.N; i++ {
+				benchmarkRead(b, img)
+			}
+		})
+		b.Run("read", func(b *testing.B) {
+			resetBenchmark(b, size)
+			for i := 0; i < b.N; i++ {
+				benchmarkConvert(b, img)
+			}
+		})
 	})
 	// TODO: qcow2 zstd (not supported yet)
 }
 
 // Benchmark sparse image with 50% utilization matching lima default image.
-func BenchmarkRead50p(b *testing.B) {
+func Benchmark50p(b *testing.B) {
 	const size = 256 * MiB
 	base := filepath.Join(b.TempDir(), "image")
 	if err := createTestImage(base, size, 0.5); err != nil {
@@ -65,27 +82,43 @@ func BenchmarkRead50p(b *testing.B) {
 		if err := qemuImgConvert(base, img, qcow2.Type, CompressionTypeNone); err != nil {
 			b.Fatal(err)
 		}
-		resetBenchmark(b, size)
-		for i := 0; i < b.N; i++ {
-			benchmarkRead(b, img)
-		}
+		b.Run("read", func(b *testing.B) {
+			resetBenchmark(b, size)
+			for i := 0; i < b.N; i++ {
+				benchmarkRead(b, img)
+			}
+		})
+		b.Run("convert", func(b *testing.B) {
+			resetBenchmark(b, size)
+			for i := 0; i < b.N; i++ {
+				benchmarkConvert(b, img)
+			}
+		})
 	})
 	b.Run("qcow2 zlib", func(b *testing.B) {
 		img := base + ".zlib.qcow2"
 		if err := qemuImgConvert(base, img, qcow2.Type, qcow2.CompressionTypeZlib); err != nil {
 			b.Fatal(err)
 		}
-		resetBenchmark(b, size)
-		for i := 0; i < b.N; i++ {
-			benchmarkRead(b, img)
-		}
+		b.Run("read", func(b *testing.B) {
+			resetBenchmark(b, size)
+			for i := 0; i < b.N; i++ {
+				benchmarkRead(b, img)
+			}
+		})
+		b.Run("convert", func(b *testing.B) {
+			resetBenchmark(b, size)
+			for i := 0; i < b.N; i++ {
+				benchmarkConvert(b, img)
+			}
+		})
 	})
 	// TODO: qcow2 zstd (not supported yet)
 }
 
 // Benchmark fully allocated image. This is the worst case for both uncompressed
 // and compressed image when we must read all clusters from storage.
-func BenchmarkRead100p(b *testing.B) {
+func Benchmark100p(b *testing.B) {
 	const size = 256 * MiB
 	base := filepath.Join(b.TempDir(), "image")
 	if err := createTestImage(base, size, 1.0); err != nil {
@@ -96,20 +129,36 @@ func BenchmarkRead100p(b *testing.B) {
 		if err := qemuImgConvert(base, img, qcow2.Type, CompressionTypeNone); err != nil {
 			b.Fatal(err)
 		}
-		resetBenchmark(b, size)
-		for i := 0; i < b.N; i++ {
-			benchmarkRead(b, img)
-		}
+		b.Run("read", func(b *testing.B) {
+			resetBenchmark(b, size)
+			for i := 0; i < b.N; i++ {
+				benchmarkRead(b, img)
+			}
+		})
+		b.Run("convert", func(b *testing.B) {
+			resetBenchmark(b, size)
+			for i := 0; i < b.N; i++ {
+				benchmarkConvert(b, img)
+			}
+		})
 	})
 	b.Run("qcow2 zlib", func(b *testing.B) {
 		img := base + ".zlib.qcow2"
 		if err := qemuImgConvert(base, img, qcow2.Type, qcow2.CompressionTypeZlib); err != nil {
 			b.Fatal(err)
 		}
-		resetBenchmark(b, size)
-		for i := 0; i < b.N; i++ {
-			benchmarkRead(b, img)
-		}
+		b.Run("read", func(b *testing.B) {
+			resetBenchmark(b, size)
+			for i := 0; i < b.N; i++ {
+				benchmarkRead(b, img)
+			}
+		})
+		b.Run("convert", func(b *testing.B) {
+			resetBenchmark(b, size)
+			for i := 0; i < b.N; i++ {
+				benchmarkConvert(b, img)
+			}
+		})
 	})
 	// TODO: qcow2 zstd (not supported yet)
 }
@@ -139,6 +188,39 @@ func benchmarkRead(b *testing.B, filename string) {
 	if n != img.Size() {
 		b.Fatalf("Expected %d bytes, read %d bytes", img.Size(), n)
 	}
+}
+
+func benchmarkConvert(b *testing.B, filename string) {
+	b.StartTimer()
+
+	f, err := os.Open(filename)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer f.Close()
+	img, err := Open(f)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer img.Close()
+	dst, err := os.Create(filename + ".out")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer dst.Close()
+	c, err := convert.New(convert.Options{})
+	if err != nil {
+		b.Fatal(err)
+	}
+	err = c.Convert(dst, img, img.Size())
+	if err != nil {
+		b.Fatal(err)
+	}
+	if err := dst.Close(); err != nil {
+		b.Fatal(err)
+	}
+
+	b.StopTimer()
 }
 
 // We cannot use io.Discard since it implements ReadFrom using small buffers


### PR DESCRIPTION
Converting images efficiently requires parallel reads and writes, keeping multiple I/O requests in flight. For compressed images we want to decompress the compressed clusters in parallel. It is not hard to implement this using the io.ReaderAt interface, but providing an implementation in this library will make it much more useful for users.

This change add a `convert` package and add it to the example program.

Testing show significant speedup for compressed images and for unallocated or zero clusters, and smaller speedup for uncompressed images.
    
| image        | size      | compression | throughput   | speedup |
|--------------|-----------|-------------|--------------|---------|
| Ubuntu 24.04 |   3.5 GiB | -           |   6.04 GiB/s |    1.51 |
| Ubuntu 24.04 |   3.5 GiB | zlib        |   1.62 GiB/s |    5.42 |
| Empty image  | 100.0 GiB | -           | 240.15 GiB/s |    7.32 |

Example usage in lima: https://github.com/lima-vm/lima/pull/2798

Fixes #32