### PR TITLE
Extract qemuimg test package

### DIFF
--- a/test/qemuimg/qemuimg.go
+++ b/test/qemuimg/qemuimg.go
@@ -1,0 +1,43 @@
+package qemuimg
+
+import (
+	"bytes"
+	"errors"
+	"os/exec"
+)
+
+type CompressionType string
+type Format string
+
+const (
+	// Compression types.
+	CompressionNone = CompressionType("")
+	CompressionZlib = CompressionType("zlib")
+	CompressionZstd = CompressionType("zstd")
+
+	// Image formats.
+	FormatQcow2 = Format("qcow2")
+	FormatRaw   = Format("raw")
+)
+
+func Convert(src, dst string, dstFormat Format, compressionType CompressionType) error {
+	args := []string{"convert", "-O", string(dstFormat)}
+	if compressionType != CompressionNone {
+		args = append(args, "-c", "-o", "compression_type="+string(compressionType))
+	}
+	args = append(args, src, dst)
+	cmd := exec.Command("qemu-img", args...)
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		// Return qemu-img stderr instead of the unhelpful default error (exited
+		// with status 1).
+		if _, ok := err.(*exec.ExitError); ok {
+			return errors.New(stderr.String())
+		}
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
The qemuimg package provides now only qemuimg.Convert(). I plan to add 
qemuimg.Create(), qemuimg.Info(), qemuimg.Map(), and qemuimg.Compare().

This makes the code nicer to work with, but adds a test only dependency.
The qcow2reader tests use now qemu2reader_test package, so the 
dependency should be built only for tests.

The qemuimg test package will also be useful for other project using
this library, since testing code using the library typically requires
creating, converting and comparing qcow2 images.