### PR TITLE
Preparing for adding block status interface

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,14 +20,14 @@ jobs:
         with:
           version: v1.52.2
           args: --verbose
-      - name: Unit tests
-        run: go test -v ./...
-      - name: Install go-qcow2reader-example
-        run: cd ./cmd/go-qcow2reader-example && go install
       - name: Install qemu-img as a test dependency
         run: |
           sudo apt-get update
           sudo apt-get install -y qemu-utils
+      - name: Unit tests
+        run: go test -v ./...
+      - name: Install go-qcow2reader-example
+        run: cd ./cmd/go-qcow2reader-example && go install
       - name: Cache test-images-ro
         id: cache-test-images-ro
         uses: actions/cache@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,14 +11,14 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.20.x
+          go-version: 1.22.x
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6.1.1
         with:
-          version: v1.52.2
+          version: v1.60.1
           args: --verbose
       - name: Install qemu-img as a test dependency
         run: |

--- a/cmd/go-qcow2reader-example/go.mod
+++ b/cmd/go-qcow2reader-example/go.mod
@@ -1,6 +1,6 @@
 module github.com/lima-vm/go-qcow2reader/cmd/go-qcow2reader-example
 
-go 1.20
+go 1.22
 
 require (
 	github.com/klauspost/compress v1.16.5

--- a/convert/convert.go
+++ b/convert/convert.go
@@ -11,7 +11,7 @@ import (
 const BufferSize = 1024 * 1024
 
 // Smaller value may increase the overhead of synchornizing multiple works.
-// Larger value may be less efficient for smaller images. The defualt value
+// Larger value may be less efficient for smaller images. The default value
 // gives good results for the lima default Ubuntu image.
 const SegmentSize = 32 * BufferSize
 
@@ -80,7 +80,7 @@ type Converter struct {
 	err    error
 }
 
-// New returns a new converter intialized from options.
+// New returns a new converter initialized from options.
 func New(opts Options) (*Converter, error) {
 	if err := opts.Validate(); err != nil {
 		return nil, err
@@ -113,7 +113,7 @@ func (c *Converter) nextSegment() (int64, int64, bool) {
 	return start, c.offset, false
 }
 
-// setError keeps the first error set. Setting the error signal other workes to
+// setError keeps the first error set. Setting the error signal other workers to
 // abort the operation.
 func (c *Converter) setError(err error) {
 	c.mutex.Lock()
@@ -166,7 +166,7 @@ func (c *Converter) Convert(wa io.WriterAt, ra io.ReaderAt, size int64) error {
 						}
 
 						// EOF for the last read of the last segment is expected, but since we
-						// read exactly size bytes, we shoud never get a zero read.
+						// read exactly size bytes, we should never get a zero read.
 						if nr == 0 {
 							c.setError(errors.New("unexpected EOF"))
 							return

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/lima-vm/go-qcow2reader
 
-go 1.20
+go 1.22

--- a/image/qcow2/qcow2.go
+++ b/image/qcow2/qcow2.go
@@ -707,7 +707,7 @@ func (img *Qcow2) readAtAligned(p []byte, off int64) (int, error) {
 	}
 	l1Index := int((off / int64(img.clusterSize)) / int64(l2Entries))
 	if l1Index >= len(img.l1Table) {
-		return 0, fmt.Errorf("index %d exceeds the L1 table length %d", l1Index, img.l1Table)
+		return 0, fmt.Errorf("index %d exceeds the L1 table length %d", l1Index, len(img.l1Table))
 	}
 	l1Entry := img.l1Table[l1Index]
 	l2TableOffset := l1Entry.l2Offset()
@@ -726,7 +726,7 @@ func (img *Qcow2) readAtAligned(p []byte, off int64) (int, error) {
 			return 0, fmt.Errorf("failed to read extended L2 table for L1 entry %v (index %d): %w", l1Entry, l1Index, err)
 		}
 		if l2Index >= len(extL2Table) {
-			return 0, fmt.Errorf("index %d exceeds the extended L2 table length %d", l2Index, extL2Table)
+			return 0, fmt.Errorf("index %d exceeds the extended L2 table length %d", l2Index, len(extL2Table))
 		}
 		extL2Entry = &extL2Table[l2Index]
 		l2Entry = extL2Entry.L2TableEntry
@@ -736,7 +736,7 @@ func (img *Qcow2) readAtAligned(p []byte, off int64) (int, error) {
 			return 0, fmt.Errorf("failed to read L2 table for L1 entry %v (index %d): %w", l1Entry, l1Index, err)
 		}
 		if l2Index >= len(l2Table) {
-			return 0, fmt.Errorf("index %d exceeds the L2 table length %d", l2Index, l2Table)
+			return 0, fmt.Errorf("index %d exceeds the L2 table length %d", l2Index, len(l2Table))
 		}
 		l2Entry = l2Table[l2Index]
 	}

--- a/test/qemuio/qemuio.go
+++ b/test/qemuio/qemuio.go
@@ -1,0 +1,52 @@
+package qemuio
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+
+	"github.com/lima-vm/go-qcow2reader/test/qemuimg"
+)
+
+// Write writes a number of bytes at a specified offset, allocating all clusters
+// in specified range.
+func Write(path string, format qemuimg.Format, off, len int64, pattern byte) error {
+	// qemu-io -f qcow2 -c 'write -P pattern off len' disk.qcow2
+	command := fmt.Sprintf("write -P %d %d %d", pattern, off, len)
+	_, err := qemuIo([]string{"-f", string(format), "-c", command, path})
+	return err
+}
+
+// Zero writes zeros at a specified offset. The behavior depens on qcow2
+// version; In qcow2 v3, allocate zero clusters, marming entire cluster as zero.
+// In qcow2 v2, if the cluster are unallocated and there is no backing file, do
+// nothing. Otherwise allocate clusters and write actual zeros.
+func Zero(path string, format qemuimg.Format, off, len int64) error {
+	// qemu-io -f qcow2 -c 'write -z off len' disk.qcow2
+	command := fmt.Sprintf("write -z %d %d", off, len)
+	_, err := qemuIo([]string{"-f", string(format), "-c", command, path})
+	return err
+}
+
+// Discard unmap number of bytes at specified offset. Allocated cluster are
+// deaallocated and replaced with zero clusters.
+func Discard(path string, format qemuimg.Format, off, len int64, unmap bool) error {
+	// qemu-io -f qcow2 -c 'write -zu off len' disk.qcow2
+	command := fmt.Sprintf("write -zu %d %d", off, len)
+	_, err := qemuIo([]string{"-f", string(format), "-c", command, path})
+	return err
+}
+
+func qemuIo(args []string) ([]byte, error) {
+	cmd := exec.Command("qemu-io", args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		if _, ok := err.(*exec.ExitError); ok {
+			return out, fmt.Errorf("%w: stderr=%q", err, stderr.String())
+		}
+		return out, err
+	}
+	return out, nil
+}


### PR DESCRIPTION
These are various fixes, refactoring and test enhancements extracted from the block status work.

- Fix typos in comments
- Fix errors formatting when index >= len(table)
- Add qemuimg.Create() helper (used in https://github.com/lima-vm/go-qcow2reader/pull/38/commits/6e3948dac2d826f79cc31e63d3f3996bef5e604c)
- Add qemuio test package (used in https://github.com/lima-vm/go-qcow2reader/pull/38/commits/6e3948dac2d826f79cc31e63d3f3996bef5e604c)
- Make qemu-img and qemu-io available for unit tests
- Separate cluster metadata from reading
- Cleanup getClusterMeta
- Upgrade to go 1.22 (used in https://github.com/lima-vm/go-qcow2reader/pull/38/commits/df846407dc77c33af467ff69fe8ca5145a5d5535)

Part-of #32