### PR TITLE
Fix read example use io.CopyBuffer

### DIFF
--- a/cmd/go-qcow2reader-example/read.go
+++ b/cmd/go-qcow2reader-example/read.go
@@ -29,7 +29,7 @@ func cmdRead(args []string) error {
 		flag.PrintDefaults()
 	}
 	fs.BoolVar(&debug, "debug", false, "enable printing debug messages")
-	fs.IntVar(&bufferSize, "buffer-size", 65536, "buffer size")
+	fs.IntVar(&bufferSize, "buffer-size", 2*1024*1024, "buffer size")
 	fs.Int64Var(&offset, "offset", 0, "offset to read")
 	fs.Int64Var(&length, "length", -1, "length to read")
 	if err := fs.Parse(args); err != nil {


### PR DESCRIPTION
Due to zero copy optimizations in os.File, using io.CopyBuffer() with
os.File and qcow2reader.Image ends as io.Copy() ignoring our buffer.
This is slow and a bad example for users of the library.

Fix the issue by hiding os.File ReadFrom method with a wrapper, forcing
io.CopyBuffer() to use our buffer.

This speeds up the copy significantly:
- Reading qcow2 image is 3.7 times faster
- Copying qcow2 image is 1.7 times faster
- Reading qcow2 compressed image is 1.05 times faster

Based on the benchmarks, update the default buffer size in the read exxample
to 2 MiB.

![buffer-size-qcow2](https://github.com/user-attachments/assets/6092e496-58c5-4680-b6f7-1a34700846e0)

Fixes: #41