### PR TITLE
Improve convert interface

### DIFF
--- a/cmd/go-qcow2reader-example/convert.go
+++ b/cmd/go-qcow2reader-example/convert.go
@@ -73,16 +73,12 @@ func cmdConvert(args []string) error {
 		return err
 	}
 
-	c, err := convert.New(options)
-	if err != nil {
-		return err
-	}
-
 	bar := newProgressBar(img.Size())
 	bar.Start()
 	defer bar.Finish()
+	options.Progress = bar
 
-	if err := c.Convert(t, img, img.Size(), bar); err != nil {
+	if err := convert.Convert(t, img, options); err != nil {
 		return err
 	}
 

--- a/qcow2reader_test.go
+++ b/qcow2reader_test.go
@@ -805,11 +805,7 @@ func benchmarkConvert(b *testing.B, filename string) {
 		b.Fatal(err)
 	}
 	defer dst.Close()
-	c, err := convert.New(convert.Options{})
-	if err != nil {
-		b.Fatal(err)
-	}
-	err = c.Convert(dst, img, img.Size(), nil)
+	err = convert.Convert(dst, img, convert.Options{})
 	if err != nil {
 		b.Fatal(err)
 	}


### PR DESCRIPTION
Creating a converter and calling converter.Convert() feels too complicated for no reason. We need to keep state during the conversion, but the user does not need to care about the internals.

Since we already made incompatible changes and clients like lima need to change, this is an opportunity to get the interface right so future changes can be backward compatible.

Changes:

- `Convert()` is now a function accepting `Options`, saving one step for the caller.
- The progress argument is now a `Progress` option, so users do not need to pass nil to disable progress.
- The size argument was removed since we can use the size of the image. If we want to support a byte range we can add start and length options without changing the function signature.
- `Converter` renamed to `conversion`, created inside `Convert()`
- Since we create a new `conversion` for each call, we don't need `reset()`
- Adding future options will not change the function signature

Example usage using defaults:

    convert.Convert(target, img, convert.Options{})

Example usage with progress bar:

    convert.Convert(target, img, convert.Options{Progress: bar})

Lima pr: https://github.com/lima-vm/lima/pull/2933