### PR TITLE
Support direct I/O

### DIFF
--- a/cmd/go-qcow2reader-example/convert.go
+++ b/cmd/go-qcow2reader-example/convert.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cheggaaa/pb/v3"
 	"github.com/lima-vm/go-qcow2reader"
 	"github.com/lima-vm/go-qcow2reader/convert"
+	"github.com/lima-vm/go-qcow2reader/directio"
 	"github.com/lima-vm/go-qcow2reader/log"
 )
 
@@ -19,6 +20,7 @@ func cmdConvert(args []string) error {
 
 		// Options
 		debug   bool
+		direct  bool
 		options convert.Options
 	)
 
@@ -28,6 +30,7 @@ func cmdConvert(args []string) error {
 		flag.PrintDefaults()
 	}
 	fs.BoolVar(&debug, "debug", false, "enable printing debug messages")
+	fs.BoolVar(&direct, "direct", false, "use direct I/O for writing")
 	fs.Int64Var(&options.SegmentSize, "segment-size", convert.SegmentSize, "worker segment size in bytes")
 	fs.IntVar(&options.BufferSize, "buffer-size", convert.BufferSize, "buffer size in bytes")
 	fs.IntVar(&options.Workers, "workers", convert.Workers, "number of workers")
@@ -63,7 +66,13 @@ func cmdConvert(args []string) error {
 	}
 	defer img.Close()
 
-	t, err := os.Create(target)
+	openFlags := os.O_CREATE | os.O_WRONLY | os.O_TRUNC
+	if direct {
+		openFlags |= directio.Flag
+		options.Alignment = directio.DefaultAlignment
+	}
+
+	t, err := os.OpenFile(target, openFlags, 0644)
 	if err != nil {
 		return err
 	}

--- a/convert/convert.go
+++ b/convert/convert.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"io"
 	"sync"
+	"unsafe"
 
+	"github.com/lima-vm/go-qcow2reader/align"
 	"github.com/lima-vm/go-qcow2reader/image"
 )
 
@@ -54,6 +56,11 @@ type Options struct {
 
 	// If set, update progress during conversion.
 	Progress Updater
+
+	// Alignment in bytes for direct I/O. When set, the write buffer is aligned
+	// to this value and the last write is padded with zeros to the alignment
+	// boundary. Must be a power of 2, and BufferSize must be a multiple of it.
+	Alignment int
 }
 
 // Validate validates options and set default values. Returns an error for
@@ -84,6 +91,15 @@ func (o *Options) Validate() error {
 	// segment size.
 	if o.SegmentSize%int64(o.BufferSize) != 0 {
 		return errors.New("segment size not aligned to buffer size")
+	}
+
+	if o.Alignment > 0 {
+		if o.Alignment&(o.Alignment-1) != 0 {
+			return errors.New("alignment must be a power of 2")
+		}
+		if o.BufferSize%o.Alignment != 0 {
+			return errors.New("buffer size not aligned to alignment")
+		}
 	}
 
 	return nil
@@ -133,6 +149,20 @@ func (c *conversion) setError(err error) {
 	c.mutex.Unlock()
 }
 
+// allocateBuffer returns a buffer suitable for the conversion. When Alignment
+// is set, the buffer's starting address is aligned to opts.Alignment.
+func allocateBuffer(opts *Options) []byte {
+	if opts.Alignment == 0 {
+		return make([]byte, opts.BufferSize)
+	}
+	buf := make([]byte, opts.BufferSize+opts.Alignment)
+	remainder := int(uintptr(unsafe.Pointer(&buf[0])) % uintptr(opts.Alignment))
+	if remainder > 0 {
+		buf = buf[opts.Alignment-remainder:]
+	}
+	return buf[:opts.BufferSize]
+}
+
 // Convert copy image to io.WriterAt. Unallocated extents in the image or read
 // data which is all zeros are converted to unallocated byte range in the target
 // image. The target image must be new empty file or a file full of zeroes. To
@@ -159,7 +189,7 @@ func Convert(wa io.WriterAt, img image.Image, opts Options) error {
 			w := worker{
 				conv: &conv,
 				opts: &opts,
-				buf:  make([]byte, opts.BufferSize),
+				buf:  allocateBuffer(&opts),
 			}
 			if err := w.run(); err != nil {
 				conv.setError(err)
@@ -211,7 +241,9 @@ func (w *worker) zeroExtent(extent image.Extent) {
 }
 
 // copyExtent copies data from the image to the target writer. Ranges that read
-// as all zeros are skipped to keep the target sparse.
+// as all zeros are skipped to keep the target sparse. When direct I/O is
+// enabled, the last write of the image is padded with zeros to the alignment
+// boundary.
 func (w *worker) copyExtent(extent image.Extent) error {
 	for extent.Length > 0 {
 		n := len(w.buf)
@@ -233,10 +265,13 @@ func (w *worker) copyExtent(extent image.Extent) error {
 		}
 
 		if !bytes.Equal(w.buf[:nr], w.conv.zero[:nr]) {
-			if nw, err := w.conv.wa.WriteAt(w.buf[:nr], extent.Start); err != nil {
+			writeLen := w.ensureAlignment(nr, extent)
+			nw, err := w.conv.wa.WriteAt(w.buf[:writeLen], extent.Start)
+			if err != nil {
 				return err
-			} else if nw != nr {
-				return fmt.Errorf("read %d, but wrote %d bytes", nr, nw)
+			}
+			if nw != writeLen {
+				return fmt.Errorf("expected to write %d, but wrote %d bytes", writeLen, nw)
 			}
 		}
 
@@ -248,4 +283,18 @@ func (w *worker) copyExtent(extent image.Extent) error {
 		extent.Start += int64(nr)
 	}
 	return nil
+}
+
+// ensureAlignment returns the write length for nr bytes. When Alignment is set
+// and this is the last extent of the image, the write length is rounded up to
+// the alignment boundary and the padding bytes are zeroed.
+func (w *worker) ensureAlignment(nr int, extent image.Extent) int {
+	if w.opts.Alignment > 0 && extent.Start+extent.Length == w.conv.size && nr%w.opts.Alignment != 0 {
+		alignedLen := align.Up(nr, w.opts.Alignment)
+		for i := nr; i < alignedLen; i++ {
+			w.buf[i] = 0
+		}
+		return alignedLen
+	}
+	return nr
 }

--- a/convert/convert.go
+++ b/convert/convert.go
@@ -93,6 +93,9 @@ type conversion struct {
 	// Read only.
 	size        int64
 	segmentSize int64
+	zero        []byte
+	wa          io.WriterAt
+	img         image.Image
 
 	// Modified during Convert, protected by the mutex.
 	mutex  sync.Mutex
@@ -140,86 +143,109 @@ func Convert(wa io.WriterAt, img image.Image, opts Options) error {
 	if err := opts.Validate(); err != nil {
 		return err
 	}
-	c := conversion{size: img.Size(), segmentSize: opts.SegmentSize}
-	zero := make([]byte, opts.BufferSize)
+	conv := conversion{
+		size:        img.Size(),
+		segmentSize: opts.SegmentSize,
+		zero:        make([]byte, opts.BufferSize),
+		wa:          wa,
+		img:         img,
+	}
 	var wg sync.WaitGroup
 
 	for i := 0; i < opts.Workers; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			buf := make([]byte, opts.BufferSize)
-			for {
-				// Get next segment to copy.
-				start, end, stop := c.nextSegment()
-				if stop {
-					return
-				}
-
-				for start < end {
-					// Get next extent in this segment.
-					extent, err := img.Extent(start, end-start)
-					if err != nil {
-						c.setError(err)
-						return
-					}
-					if extent.Zero {
-						start += extent.Length
-						if opts.Progress != nil {
-							opts.Progress.Update(extent.Length)
-						}
-						continue
-					}
-
-					// Consume data from this extent.
-					for extent.Length > 0 {
-						// The last read may be shorter.
-						n := len(buf)
-						if extent.Length < int64(len(buf)) {
-							n = int(extent.Length)
-						}
-
-						// Read more data.
-						nr, err := img.ReadAt(buf[:n], start)
-						if err != nil {
-							if !errors.Is(err, io.EOF) {
-								c.setError(err)
-								return
-							}
-
-							// EOF for the last read of the last segment is expected, but since we
-							// read exactly size bytes, we should never get a zero read.
-							if nr == 0 {
-								c.setError(errors.New("unexpected EOF"))
-								return
-							}
-						}
-
-						// If the data is all zeros we skip it to create a hole. Otherwise
-						// write the data.
-						if !bytes.Equal(buf[:nr], zero[:nr]) {
-							if nw, err := wa.WriteAt(buf[:nr], start); err != nil {
-								c.setError(err)
-								return
-							} else if nw != nr {
-								c.setError(fmt.Errorf("read %d, but wrote %d bytes", nr, nw))
-								return
-							}
-						}
-
-						if opts.Progress != nil {
-							opts.Progress.Update(int64(nr))
-						}
-
-						extent.Length -= int64(nr)
-						extent.Start += int64(nr)
-						start += int64(nr)
-					}
-				}
+			w := worker{
+				conv: &conv,
+				opts: &opts,
+				buf:  make([]byte, opts.BufferSize),
+			}
+			if err := w.run(); err != nil {
+				conv.setError(err)
 			}
 		}()
 	}
 
 	wg.Wait()
-	return c.err
+	return conv.err
+}
+
+type worker struct {
+	conv *conversion
+	opts *Options
+	buf  []byte
+}
+
+func (w *worker) run() error {
+	for {
+		start, end, stop := w.conv.nextSegment()
+		if stop {
+			return nil
+		}
+
+		for start < end {
+			extent, err := w.conv.img.Extent(start, end-start)
+			if err != nil {
+				return err
+			}
+
+			if extent.Zero {
+				w.zeroExtent(extent)
+			} else if err := w.copyExtent(extent); err != nil {
+				return err
+			}
+
+			start += extent.Length
+		}
+	}
+}
+
+// zeroExtent ensures that the extent is full of zeros in the target. Currently
+// a no-op since we assume a new sparse file, but should punch a hole in the
+// future.
+func (w *worker) zeroExtent(extent image.Extent) {
+	if w.opts.Progress != nil {
+		w.opts.Progress.Update(extent.Length)
+	}
+}
+
+// copyExtent copies data from the image to the target writer. Ranges that read
+// as all zeros are skipped to keep the target sparse.
+func (w *worker) copyExtent(extent image.Extent) error {
+	for extent.Length > 0 {
+		n := len(w.buf)
+		if extent.Length < int64(len(w.buf)) {
+			n = int(extent.Length)
+		}
+
+		nr, err := w.conv.img.ReadAt(w.buf[:n], extent.Start)
+		if err != nil {
+			if !errors.Is(err, io.EOF) {
+				return err
+			}
+
+			// EOF for the last read of the last segment is expected, but since we
+			// read exactly size bytes, we should never get a zero read.
+			if nr == 0 {
+				return errors.New("unexpected EOF")
+			}
+		}
+
+		if !bytes.Equal(w.buf[:nr], w.conv.zero[:nr]) {
+			if nw, err := w.conv.wa.WriteAt(w.buf[:nr], extent.Start); err != nil {
+				return err
+			} else if nw != nr {
+				return fmt.Errorf("read %d, but wrote %d bytes", nr, nw)
+			}
+		}
+
+		if w.opts.Progress != nil {
+			w.opts.Progress.Update(int64(nr))
+		}
+
+		extent.Length -= int64(nr)
+		extent.Start += int64(nr)
+	}
+	return nil
 }

--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -9,6 +9,7 @@ import (
 	"unsafe"
 
 	"github.com/lima-vm/go-qcow2reader"
+	"github.com/lima-vm/go-qcow2reader/directio"
 	"github.com/lima-vm/go-qcow2reader/test/qemuimg"
 	"github.com/lima-vm/go-qcow2reader/test/testimage"
 	. "github.com/lima-vm/go-qcow2reader/test/units" //nolint:staticcheck
@@ -83,7 +84,7 @@ func TestAllocateBufferAligned(t *testing.T) {
 // Benchmark completely empty sparse image (0% utilization). This is the best
 // case when we don't have to read any cluster from storage.
 func BenchmarkConvert0p(b *testing.B) {
-	const size = 256 * MiB
+	const size = 2 * GiB
 	base := filepath.Join(tempDir(b), "image")
 	if err := testimage.Create(base, size, 0.0); err != nil {
 		b.Fatal(err)
@@ -93,26 +94,42 @@ func BenchmarkConvert0p(b *testing.B) {
 		if err := qemuimg.Convert(base, img, qemuimg.FormatQcow2, qemuimg.CompressionNone); err != nil {
 			b.Fatal(err)
 		}
-		resetBenchmark(b, size)
-		for i := 0; i < b.N; i++ {
-			benchmarkConvert(b, img, Options{})
-		}
+		b.Run("buffered", func(b *testing.B) {
+			resetBenchmark(b, size)
+			for i := 0; i < b.N; i++ {
+				benchmarkConvert(b, img, Options{}, 0)
+			}
+		})
+		b.Run("direct", func(b *testing.B) {
+			resetBenchmark(b, size)
+			for i := 0; i < b.N; i++ {
+				benchmarkConvert(b, img, Options{Alignment: directio.DefaultAlignment}, directio.Flag)
+			}
+		})
 	})
 	b.Run("qcow2 zlib", func(b *testing.B) {
 		img := base + ".zlib.qcow2"
 		if err := qemuimg.Convert(base, img, qemuimg.FormatQcow2, qemuimg.CompressionZlib); err != nil {
 			b.Fatal(err)
 		}
-		resetBenchmark(b, size)
-		for i := 0; i < b.N; i++ {
-			benchmarkConvert(b, img, Options{})
-		}
+		b.Run("buffered", func(b *testing.B) {
+			resetBenchmark(b, size)
+			for i := 0; i < b.N; i++ {
+				benchmarkConvert(b, img, Options{}, 0)
+			}
+		})
+		b.Run("direct", func(b *testing.B) {
+			resetBenchmark(b, size)
+			for i := 0; i < b.N; i++ {
+				benchmarkConvert(b, img, Options{Alignment: directio.DefaultAlignment}, directio.Flag)
+			}
+		})
 	})
 }
 
 // Benchmark sparse image with 50% utilization matching lima default image.
 func BenchmarkConvert50p(b *testing.B) {
-	const size = 256 * MiB
+	const size = 2 * GiB
 	base := filepath.Join(tempDir(b), "image")
 	if err := testimage.Create(base, size, 0.5); err != nil {
 		b.Fatal(err)
@@ -122,27 +139,43 @@ func BenchmarkConvert50p(b *testing.B) {
 		if err := qemuimg.Convert(base, img, qemuimg.FormatQcow2, qemuimg.CompressionNone); err != nil {
 			b.Fatal(err)
 		}
-		resetBenchmark(b, size)
-		for i := 0; i < b.N; i++ {
-			benchmarkConvert(b, img, Options{})
-		}
+		b.Run("buffered", func(b *testing.B) {
+			resetBenchmark(b, size)
+			for i := 0; i < b.N; i++ {
+				benchmarkConvert(b, img, Options{}, 0)
+			}
+		})
+		b.Run("direct", func(b *testing.B) {
+			resetBenchmark(b, size)
+			for i := 0; i < b.N; i++ {
+				benchmarkConvert(b, img, Options{Alignment: directio.DefaultAlignment}, directio.Flag)
+			}
+		})
 	})
 	b.Run("qcow2 zlib", func(b *testing.B) {
 		img := base + ".zlib.qcow2"
 		if err := qemuimg.Convert(base, img, qemuimg.FormatQcow2, qemuimg.CompressionZlib); err != nil {
 			b.Fatal(err)
 		}
-		resetBenchmark(b, size)
-		for i := 0; i < b.N; i++ {
-			benchmarkConvert(b, img, Options{})
-		}
+		b.Run("buffered", func(b *testing.B) {
+			resetBenchmark(b, size)
+			for i := 0; i < b.N; i++ {
+				benchmarkConvert(b, img, Options{}, 0)
+			}
+		})
+		b.Run("direct", func(b *testing.B) {
+			resetBenchmark(b, size)
+			for i := 0; i < b.N; i++ {
+				benchmarkConvert(b, img, Options{Alignment: directio.DefaultAlignment}, directio.Flag)
+			}
+		})
 	})
 }
 
 // Benchmark fully allocated image. This is the worst case for both uncompressed
 // and compressed image when we must read all clusters from storage.
 func BenchmarkConvert100p(b *testing.B) {
-	const size = 256 * MiB
+	const size = 2 * GiB
 	base := filepath.Join(tempDir(b), "image")
 	if err := testimage.Create(base, size, 1.0); err != nil {
 		b.Fatal(err)
@@ -152,24 +185,40 @@ func BenchmarkConvert100p(b *testing.B) {
 		if err := qemuimg.Convert(base, img, qemuimg.FormatQcow2, qemuimg.CompressionNone); err != nil {
 			b.Fatal(err)
 		}
-		resetBenchmark(b, size)
-		for i := 0; i < b.N; i++ {
-			benchmarkConvert(b, img, Options{})
-		}
+		b.Run("buffered", func(b *testing.B) {
+			resetBenchmark(b, size)
+			for i := 0; i < b.N; i++ {
+				benchmarkConvert(b, img, Options{}, 0)
+			}
+		})
+		b.Run("direct", func(b *testing.B) {
+			resetBenchmark(b, size)
+			for i := 0; i < b.N; i++ {
+				benchmarkConvert(b, img, Options{Alignment: directio.DefaultAlignment}, directio.Flag)
+			}
+		})
 	})
 	b.Run("qcow2 zlib", func(b *testing.B) {
 		img := base + ".zlib.qcow2"
 		if err := qemuimg.Convert(base, img, qemuimg.FormatQcow2, qemuimg.CompressionZlib); err != nil {
 			b.Fatal(err)
 		}
-		resetBenchmark(b, size)
-		for i := 0; i < b.N; i++ {
-			benchmarkConvert(b, img, Options{})
-		}
+		b.Run("buffered", func(b *testing.B) {
+			resetBenchmark(b, size)
+			for i := 0; i < b.N; i++ {
+				benchmarkConvert(b, img, Options{}, 0)
+			}
+		})
+		b.Run("direct", func(b *testing.B) {
+			resetBenchmark(b, size)
+			for i := 0; i < b.N; i++ {
+				benchmarkConvert(b, img, Options{Alignment: directio.DefaultAlignment}, directio.Flag)
+			}
+		})
 	})
 }
 
-func benchmarkConvert(b *testing.B, filename string, opts Options) {
+func benchmarkConvert(b *testing.B, filename string, opts Options, openFlags int) {
 	b.StartTimer()
 
 	f, err := os.Open(filename)
@@ -182,7 +231,8 @@ func benchmarkConvert(b *testing.B, filename string, opts Options) {
 		b.Fatal(err)
 	}
 	defer img.Close() //nolint:errcheck
-	dst, err := os.Create(filename + ".out")
+	dstFlags := os.O_CREATE | os.O_WRONLY | os.O_TRUNC | openFlags
+	dst, err := os.OpenFile(filename+".out", dstFlags, 0600)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -1,0 +1,73 @@
+package convert
+
+import (
+	"fmt"
+	"testing"
+	"unsafe"
+)
+
+func TestValidateAlignment(t *testing.T) {
+	for _, alignment := range []int{512, 4096} {
+		t.Run(fmt.Sprintf("%d", alignment), func(t *testing.T) {
+			opts := Options{Alignment: alignment}
+			if err := opts.Validate(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestValidateAlignmentInvalid(t *testing.T) {
+	tests := []struct {
+		name string
+		opts Options
+	}{
+		{
+			name: "alignment not power of 2",
+			opts: Options{Alignment: 3000},
+		},
+		{
+			name: "buffer size not aligned",
+			opts: Options{Alignment: 4096, BufferSize: 5000, SegmentSize: 5000},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.opts.Validate(); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
+func TestAllocateBuffer(t *testing.T) {
+	opts := Options{}
+	if err := opts.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	buf := allocateBuffer(&opts)
+	if len(buf) != opts.BufferSize {
+		t.Fatalf("expected len %d, got %d", opts.BufferSize, len(buf))
+	}
+}
+
+func TestAllocateBufferAligned(t *testing.T) {
+	for _, alignment := range []int{512, 4096} {
+		t.Run(fmt.Sprintf("%d", alignment), func(t *testing.T) {
+			opts := Options{
+				Alignment: alignment,
+			}
+			if err := opts.Validate(); err != nil {
+				t.Fatal(err)
+			}
+			buf := allocateBuffer(&opts)
+			if len(buf) != opts.BufferSize {
+				t.Fatalf("expected len %d, got %d", opts.BufferSize, len(buf))
+			}
+			addr := uintptr(unsafe.Pointer(&buf[0]))
+			if addr%uintptr(alignment) != 0 {
+				t.Fatalf("buffer address %x not aligned to %d", addr, alignment)
+			}
+		})
+	}
+}

--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"unsafe"
 
@@ -83,7 +84,7 @@ func TestAllocateBufferAligned(t *testing.T) {
 // case when we don't have to read any cluster from storage.
 func BenchmarkConvert0p(b *testing.B) {
 	const size = 256 * MiB
-	base := filepath.Join(b.TempDir(), "image")
+	base := filepath.Join(tempDir(b), "image")
 	if err := testimage.Create(base, size, 0.0); err != nil {
 		b.Fatal(err)
 	}
@@ -112,7 +113,7 @@ func BenchmarkConvert0p(b *testing.B) {
 // Benchmark sparse image with 50% utilization matching lima default image.
 func BenchmarkConvert50p(b *testing.B) {
 	const size = 256 * MiB
-	base := filepath.Join(b.TempDir(), "image")
+	base := filepath.Join(tempDir(b), "image")
 	if err := testimage.Create(base, size, 0.5); err != nil {
 		b.Fatal(err)
 	}
@@ -142,7 +143,7 @@ func BenchmarkConvert50p(b *testing.B) {
 // and compressed image when we must read all clusters from storage.
 func BenchmarkConvert100p(b *testing.B) {
 	const size = 256 * MiB
-	base := filepath.Join(b.TempDir(), "image")
+	base := filepath.Join(tempDir(b), "image")
 	if err := testimage.Create(base, size, 1.0); err != nil {
 		b.Fatal(err)
 	}
@@ -201,4 +202,19 @@ func resetBenchmark(b *testing.B, size int64) {
 	b.ResetTimer()
 	b.SetBytes(size)
 	b.ReportAllocs()
+}
+
+// tempDir creates a temporary directory suitable for direct I/O testing. On
+// Linux, /tmp is typically tmpfs which does not support O_DIRECT, so we use
+// /var/tmp instead. On other systems the standard temp directory should work.
+func tempDir(b *testing.B) string {
+	if runtime.GOOS != "linux" {
+		return b.TempDir()
+	}
+	dir, err := os.MkdirTemp("/var/tmp", "go-qcow2reader-"+b.Name()+"-")
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
 }

--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -237,6 +237,9 @@ func benchmarkConvert(b *testing.B, filename string, opts Options, openFlags int
 		b.Fatal(err)
 	}
 	defer dst.Close() //nolint:errcheck
+	if err := dst.Truncate(img.Size()); err != nil {
+		b.Fatal(err)
+	}
 	if err := Convert(dst, img, opts); err != nil {
 		b.Fatal(err)
 	}

--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -2,8 +2,15 @@ package convert
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 	"unsafe"
+
+	"github.com/lima-vm/go-qcow2reader"
+	"github.com/lima-vm/go-qcow2reader/test/qemuimg"
+	"github.com/lima-vm/go-qcow2reader/test/testimage"
+	. "github.com/lima-vm/go-qcow2reader/test/units" //nolint:staticcheck
 )
 
 func TestValidateAlignment(t *testing.T) {
@@ -70,4 +77,128 @@ func TestAllocateBufferAligned(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Benchmark completely empty sparse image (0% utilization). This is the best
+// case when we don't have to read any cluster from storage.
+func BenchmarkConvert0p(b *testing.B) {
+	const size = 256 * MiB
+	base := filepath.Join(b.TempDir(), "image")
+	if err := testimage.Create(base, size, 0.0); err != nil {
+		b.Fatal(err)
+	}
+	b.Run("qcow2", func(b *testing.B) {
+		img := base + ".qcow2"
+		if err := qemuimg.Convert(base, img, qemuimg.FormatQcow2, qemuimg.CompressionNone); err != nil {
+			b.Fatal(err)
+		}
+		resetBenchmark(b, size)
+		for i := 0; i < b.N; i++ {
+			benchmarkConvert(b, img, Options{})
+		}
+	})
+	b.Run("qcow2 zlib", func(b *testing.B) {
+		img := base + ".zlib.qcow2"
+		if err := qemuimg.Convert(base, img, qemuimg.FormatQcow2, qemuimg.CompressionZlib); err != nil {
+			b.Fatal(err)
+		}
+		resetBenchmark(b, size)
+		for i := 0; i < b.N; i++ {
+			benchmarkConvert(b, img, Options{})
+		}
+	})
+}
+
+// Benchmark sparse image with 50% utilization matching lima default image.
+func BenchmarkConvert50p(b *testing.B) {
+	const size = 256 * MiB
+	base := filepath.Join(b.TempDir(), "image")
+	if err := testimage.Create(base, size, 0.5); err != nil {
+		b.Fatal(err)
+	}
+	b.Run("qcow2", func(b *testing.B) {
+		img := base + ".qcow2"
+		if err := qemuimg.Convert(base, img, qemuimg.FormatQcow2, qemuimg.CompressionNone); err != nil {
+			b.Fatal(err)
+		}
+		resetBenchmark(b, size)
+		for i := 0; i < b.N; i++ {
+			benchmarkConvert(b, img, Options{})
+		}
+	})
+	b.Run("qcow2 zlib", func(b *testing.B) {
+		img := base + ".zlib.qcow2"
+		if err := qemuimg.Convert(base, img, qemuimg.FormatQcow2, qemuimg.CompressionZlib); err != nil {
+			b.Fatal(err)
+		}
+		resetBenchmark(b, size)
+		for i := 0; i < b.N; i++ {
+			benchmarkConvert(b, img, Options{})
+		}
+	})
+}
+
+// Benchmark fully allocated image. This is the worst case for both uncompressed
+// and compressed image when we must read all clusters from storage.
+func BenchmarkConvert100p(b *testing.B) {
+	const size = 256 * MiB
+	base := filepath.Join(b.TempDir(), "image")
+	if err := testimage.Create(base, size, 1.0); err != nil {
+		b.Fatal(err)
+	}
+	b.Run("qcow2", func(b *testing.B) {
+		img := base + ".qcow2"
+		if err := qemuimg.Convert(base, img, qemuimg.FormatQcow2, qemuimg.CompressionNone); err != nil {
+			b.Fatal(err)
+		}
+		resetBenchmark(b, size)
+		for i := 0; i < b.N; i++ {
+			benchmarkConvert(b, img, Options{})
+		}
+	})
+	b.Run("qcow2 zlib", func(b *testing.B) {
+		img := base + ".zlib.qcow2"
+		if err := qemuimg.Convert(base, img, qemuimg.FormatQcow2, qemuimg.CompressionZlib); err != nil {
+			b.Fatal(err)
+		}
+		resetBenchmark(b, size)
+		for i := 0; i < b.N; i++ {
+			benchmarkConvert(b, img, Options{})
+		}
+	})
+}
+
+func benchmarkConvert(b *testing.B, filename string, opts Options) {
+	b.StartTimer()
+
+	f, err := os.Open(filename)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer f.Close() //nolint:errcheck
+	img, err := qcow2reader.Open(f)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer img.Close() //nolint:errcheck
+	dst, err := os.Create(filename + ".out")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer dst.Close() //nolint:errcheck
+	if err := Convert(dst, img, opts); err != nil {
+		b.Fatal(err)
+	}
+	if err := dst.Close(); err != nil {
+		b.Fatal(err)
+	}
+
+	b.StopTimer()
+}
+
+func resetBenchmark(b *testing.B, size int64) {
+	b.StopTimer()
+	b.ResetTimer()
+	b.SetBytes(size)
+	b.ReportAllocs()
 }

--- a/directio/directio.go
+++ b/directio/directio.go
@@ -1,0 +1,15 @@
+// Platforms that define syscall.O_DIRECT, verified by checking for O_DIRECT in
+// zerrors_*_*.go in the Go source ($GOROOT/src/syscall).
+// When changing these tags, update directio_other.go to match.
+//go:build linux || freebsd || netbsd || dragonfly || aix
+
+package directio
+
+import "syscall"
+
+// Flag is the open flag for direct I/O.
+const Flag = syscall.O_DIRECT
+
+// DefaultAlignment is a safe default buffer alignment for direct I/O. The
+// actual requirement may be lower depending on the file system or block device.
+const DefaultAlignment = 4096

--- a/directio/directio_other.go
+++ b/directio/directio_other.go
@@ -1,0 +1,13 @@
+// Must match the negation of the build tags in directio.go.
+//go:build !linux && !freebsd && !netbsd && !dragonfly && !aix && !windows
+
+package directio
+
+import "syscall"
+
+// Flag is the open flag for direct I/O. On platforms without O_DIRECT, we use
+// O_DSYNC to emulate direct I/O, same as QEMU.
+const Flag = syscall.O_DSYNC
+
+// DefaultAlignment is 0 since O_DSYNC does not require aligned buffers.
+const DefaultAlignment = 0

--- a/directio/directio_windows.go
+++ b/directio/directio_windows.go
@@ -1,0 +1,11 @@
+package directio
+
+// Flag is the open flag for direct I/O. Windows supports direct I/O via
+// FILE_FLAG_NO_BUFFERING (0x20000000), but syscall.Open only passes this flag
+// to CreateFile since Go 1.26. When we require Go 1.26, set Flag to
+// 0x20000000 and DefaultAlignment to 4096.
+// https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea#FILE_FLAG_NO_BUFFERING
+const Flag = 0
+
+// DefaultAlignment is 0 since Flag is not set.
+const DefaultAlignment = 0

--- a/hack/compare-with-qemu-img.sh
+++ b/hack/compare-with-qemu-img.sh
@@ -9,6 +9,7 @@ name_qcow2="$1"
 name_raw_a="${name_qcow2}.raw_a"
 name_raw_b="${name_qcow2}.raw_b"
 name_raw_c="${name_qcow2}.raw_c"
+name_raw_d="${name_qcow2}.raw_d"
 
 echo "Input file: ${name_qcow2}"
 set -x
@@ -43,6 +44,13 @@ go-qcow2reader-example convert "${name_qcow2}" "${name_raw_c}"
 sha256sum "${name_raw_c}" | tee "${name_raw_c}.sha256"
 set +x
 
+rm -f "${name_raw_d}" "${name_raw_d}.sha256"
+echo "Converting ${name_qcow2} to ${name_raw_d} with go-qcow2reader convert -direct"
+set -x
+go-qcow2reader-example convert -direct "${name_qcow2}" "${name_raw_d}"
+sha256sum "${name_raw_d}" | tee "${name_raw_d}.sha256"
+set +x
+
 expected="$(cut -d " " -f 1 <"${name_raw_a}.sha256")"
 
 got="$(cut -d " " -f 1 <"${name_raw_b}.sha256")"
@@ -67,6 +75,17 @@ else
 	exit 1
 fi
 
+got="$(cut -d " " -f 1 <"${name_raw_d}.sha256")"
+echo "Comparing: ${expected} vs ${got}"
+if [ "${expected}" = "${got}" ]; then
+	echo "OK"
+else
+	echo "FAIL"
+	set -x
+	qemu-img compare "${name_raw_a}" "${name_raw_d}"
+	exit 1
+fi
+
 echo "===== Phase 2: random read ====="
 for offset in 1 22 333 4444 55555 666666 7777777 88888888; do
 	for length in 1 22 333 4444 55555 666666 7777777 88888888; do
@@ -88,5 +107,5 @@ done
 
 echo "===== Cleaning up... ====="
 set -x
-rm -f "${name_raw_b}" "${name_raw_b}.sha256" "${name_raw_c}" "${name_raw_c}.sha256"
+rm -f "${name_raw_b}" "${name_raw_b}.sha256" "${name_raw_c}" "${name_raw_c}.sha256" "${name_raw_d}" "${name_raw_d}.sha256"
 set +x

--- a/qcow2reader_test.go
+++ b/qcow2reader_test.go
@@ -15,12 +15,10 @@ import (
 	"github.com/lima-vm/go-qcow2reader/image"
 	"github.com/lima-vm/go-qcow2reader/test/qemuimg"
 	"github.com/lima-vm/go-qcow2reader/test/qemuio"
+	. "github.com/lima-vm/go-qcow2reader/test/units" //nolint:staticcheck
 )
 
 const (
-	KiB         = int64(1) << 10
-	MiB         = int64(1) << 20
-	GiB         = int64(1) << 30
 	clusterSize = 64 * KiB
 )
 

--- a/qcow2reader_test.go
+++ b/qcow2reader_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/lima-vm/go-qcow2reader"
-	"github.com/lima-vm/go-qcow2reader/convert"
 	"github.com/lima-vm/go-qcow2reader/image"
 	"github.com/lima-vm/go-qcow2reader/test/qemuimg"
 	"github.com/lima-vm/go-qcow2reader/test/testimage"
@@ -575,144 +574,93 @@ func listExtents(path string) ([]image.Extent, error) {
 	return extents, nil
 }
 
-// Benchmark completely empty sparse image (0% utilization).  This is the best
+// Benchmark completely empty sparse image (0% utilization). This is the best
 // case when we don't have to read any cluster from storage.
-func Benchmark0p(b *testing.B) {
+func BenchmarkRead0p(b *testing.B) {
 	const size = 256 * MiB
 	base := filepath.Join(b.TempDir(), "image")
 	if err := testimage.Create(base, size, 0.0); err != nil {
 		b.Fatal(err)
 	}
 	b.Run("qcow2", func(b *testing.B) {
-		img := base + ".qocw2"
+		img := base + ".qcow2"
 		if err := qemuimg.Convert(base, img, qemuimg.FormatQcow2, qemuimg.CompressionNone); err != nil {
 			b.Fatal(err)
 		}
-		b.Run("read", func(b *testing.B) {
-			resetBenchmark(b, size)
-			for i := 0; i < b.N; i++ {
-				benchmarkRead(b, img)
-			}
-		})
-		b.Run("convert", func(b *testing.B) {
-			resetBenchmark(b, size)
-			for i := 0; i < b.N; i++ {
-				benchmarkConvert(b, img)
-			}
-		})
+		resetBenchmark(b, size)
+		for i := 0; i < b.N; i++ {
+			benchmarkRead(b, img)
+		}
 	})
 	b.Run("qcow2 zlib", func(b *testing.B) {
 		img := base + ".zlib.qcow2"
 		if err := qemuimg.Convert(base, img, qemuimg.FormatQcow2, qemuimg.CompressionZlib); err != nil {
 			b.Fatal(err)
 		}
-		b.Run("read", func(b *testing.B) {
-			resetBenchmark(b, size)
-			for i := 0; i < b.N; i++ {
-				benchmarkRead(b, img)
-			}
-		})
-		b.Run("read", func(b *testing.B) {
-			resetBenchmark(b, size)
-			for i := 0; i < b.N; i++ {
-				benchmarkConvert(b, img)
-			}
-		})
+		resetBenchmark(b, size)
+		for i := 0; i < b.N; i++ {
+			benchmarkRead(b, img)
+		}
 	})
-	// TODO: qcow2 zstd (not supported yet)
 }
 
 // Benchmark sparse image with 50% utilization matching lima default image.
-func Benchmark50p(b *testing.B) {
+func BenchmarkRead50p(b *testing.B) {
 	const size = 256 * MiB
 	base := filepath.Join(b.TempDir(), "image")
 	if err := testimage.Create(base, size, 0.5); err != nil {
 		b.Fatal(err)
 	}
 	b.Run("qcow2", func(b *testing.B) {
-		img := base + ".qocw2"
+		img := base + ".qcow2"
 		if err := qemuimg.Convert(base, img, qemuimg.FormatQcow2, qemuimg.CompressionNone); err != nil {
 			b.Fatal(err)
 		}
-		b.Run("read", func(b *testing.B) {
-			resetBenchmark(b, size)
-			for i := 0; i < b.N; i++ {
-				benchmarkRead(b, img)
-			}
-		})
-		b.Run("convert", func(b *testing.B) {
-			resetBenchmark(b, size)
-			for i := 0; i < b.N; i++ {
-				benchmarkConvert(b, img)
-			}
-		})
+		resetBenchmark(b, size)
+		for i := 0; i < b.N; i++ {
+			benchmarkRead(b, img)
+		}
 	})
 	b.Run("qcow2 zlib", func(b *testing.B) {
 		img := base + ".zlib.qcow2"
 		if err := qemuimg.Convert(base, img, qemuimg.FormatQcow2, qemuimg.CompressionZlib); err != nil {
 			b.Fatal(err)
 		}
-		b.Run("read", func(b *testing.B) {
-			resetBenchmark(b, size)
-			for i := 0; i < b.N; i++ {
-				benchmarkRead(b, img)
-			}
-		})
-		b.Run("convert", func(b *testing.B) {
-			resetBenchmark(b, size)
-			for i := 0; i < b.N; i++ {
-				benchmarkConvert(b, img)
-			}
-		})
+		resetBenchmark(b, size)
+		for i := 0; i < b.N; i++ {
+			benchmarkRead(b, img)
+		}
 	})
-	// TODO: qcow2 zstd (not supported yet)
 }
 
 // Benchmark fully allocated image. This is the worst case for both uncompressed
 // and compressed image when we must read all clusters from storage.
-func Benchmark100p(b *testing.B) {
+func BenchmarkRead100p(b *testing.B) {
 	const size = 256 * MiB
 	base := filepath.Join(b.TempDir(), "image")
 	if err := testimage.Create(base, size, 1.0); err != nil {
 		b.Fatal(err)
 	}
 	b.Run("qcow2", func(b *testing.B) {
-		img := base + ".qocw2"
+		img := base + ".qcow2"
 		if err := qemuimg.Convert(base, img, qemuimg.FormatQcow2, qemuimg.CompressionNone); err != nil {
 			b.Fatal(err)
 		}
-		b.Run("read", func(b *testing.B) {
-			resetBenchmark(b, size)
-			for i := 0; i < b.N; i++ {
-				benchmarkRead(b, img)
-			}
-		})
-		b.Run("convert", func(b *testing.B) {
-			resetBenchmark(b, size)
-			for i := 0; i < b.N; i++ {
-				benchmarkConvert(b, img)
-			}
-		})
+		resetBenchmark(b, size)
+		for i := 0; i < b.N; i++ {
+			benchmarkRead(b, img)
+		}
 	})
 	b.Run("qcow2 zlib", func(b *testing.B) {
 		img := base + ".zlib.qcow2"
 		if err := qemuimg.Convert(base, img, qemuimg.FormatQcow2, qemuimg.CompressionZlib); err != nil {
 			b.Fatal(err)
 		}
-		b.Run("read", func(b *testing.B) {
-			resetBenchmark(b, size)
-			for i := 0; i < b.N; i++ {
-				benchmarkRead(b, img)
-			}
-		})
-		b.Run("convert", func(b *testing.B) {
-			resetBenchmark(b, size)
-			for i := 0; i < b.N; i++ {
-				benchmarkConvert(b, img)
-			}
-		})
+		resetBenchmark(b, size)
+		for i := 0; i < b.N; i++ {
+			benchmarkRead(b, img)
+		}
 	})
-	// TODO: qcow2 zstd (not supported yet)
 }
 
 func benchmarkRead(b *testing.B, filename string) {
@@ -740,35 +688,6 @@ func benchmarkRead(b *testing.B, filename string) {
 	if n != img.Size() {
 		b.Fatalf("Expected %d bytes, read %d bytes", img.Size(), n)
 	}
-}
-
-func benchmarkConvert(b *testing.B, filename string) {
-	b.StartTimer()
-
-	f, err := os.Open(filename)
-	if err != nil {
-		b.Fatal(err)
-	}
-	defer f.Close() //nolint:errcheck
-	img, err := qcow2reader.Open(f)
-	if err != nil {
-		b.Fatal(err)
-	}
-	defer img.Close() //nolint:errcheck
-	dst, err := os.Create(filename + ".out")
-	if err != nil {
-		b.Fatal(err)
-	}
-	defer dst.Close() //nolint:errcheck
-	err = convert.Convert(dst, img, convert.Options{})
-	if err != nil {
-		b.Fatal(err)
-	}
-	if err := dst.Close(); err != nil {
-		b.Fatal(err)
-	}
-
-	b.StopTimer()
 }
 
 // We cannot use io.Discard since it implements ReadFrom using small buffers

--- a/qcow2reader_test.go
+++ b/qcow2reader_test.go
@@ -4,7 +4,6 @@ package qcow2reader_test
 import (
 	"fmt"
 	"io"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"slices"
@@ -14,7 +13,7 @@ import (
 	"github.com/lima-vm/go-qcow2reader/convert"
 	"github.com/lima-vm/go-qcow2reader/image"
 	"github.com/lima-vm/go-qcow2reader/test/qemuimg"
-	"github.com/lima-vm/go-qcow2reader/test/qemuio"
+	"github.com/lima-vm/go-qcow2reader/test/testimage"
 	. "github.com/lima-vm/go-qcow2reader/test/units" //nolint:staticcheck
 )
 
@@ -214,7 +213,7 @@ func TestExtentsSome(t *testing.T) {
 		{Start: 1016 * clusterSize, Length: 8984 * clusterSize, Zero: true},
 	}
 	qcow2 := filepath.Join(t.TempDir(), "image")
-	if err := createTestImageWithExtents(qcow2, qemuimg.FormatQcow2, extents, "", ""); err != nil {
+	if err := testimage.CreateWithExtents(qcow2, qemuimg.FormatQcow2, extents, "", ""); err != nil {
 		t.Fatal(err)
 	}
 	t.Run("qcow2", func(t *testing.T) {
@@ -257,7 +256,7 @@ func TestExtentsPartial(t *testing.T) {
 	}
 
 	qcow2 := filepath.Join(t.TempDir(), "image")
-	if err := createTestImageWithExtents(qcow2, qemuimg.FormatQcow2, extents, "", ""); err != nil {
+	if err := testimage.CreateWithExtents(qcow2, qemuimg.FormatQcow2, extents, "", ""); err != nil {
 		t.Fatal(err)
 	}
 	t.Run("qcow2", func(t *testing.T) {
@@ -302,7 +301,7 @@ func TestExtentsMerge(t *testing.T) {
 	}
 
 	qcow2 := filepath.Join(t.TempDir(), "image")
-	if err := createTestImageWithExtents(qcow2, qemuimg.FormatQcow2, extents, "", ""); err != nil {
+	if err := testimage.CreateWithExtents(qcow2, qemuimg.FormatQcow2, extents, "", ""); err != nil {
 		t.Fatal(err)
 	}
 	t.Run("qcow2", func(t *testing.T) {
@@ -337,7 +336,7 @@ func TestExtentsZero(t *testing.T) {
 	}
 
 	qcow2 := filepath.Join(t.TempDir(), "image")
-	if err := createTestImageWithExtents(qcow2, qemuimg.FormatQcow2, extents, "", ""); err != nil {
+	if err := testimage.CreateWithExtents(qcow2, qemuimg.FormatQcow2, extents, "", ""); err != nil {
 		t.Fatal(err)
 	}
 	t.Run("qcow2", func(t *testing.T) {
@@ -391,7 +390,7 @@ func TestExtentsBackingFile(t *testing.T) {
 		{Start: 999 * clusterSize, Length: 1 * clusterSize, Allocated: true},
 	}
 	baseRaw := filepath.Join(tmpDir, "base.raw")
-	if err := createTestImageWithExtents(baseRaw, qemuimg.FormatRaw, baseExtents, "", ""); err != nil {
+	if err := testimage.CreateWithExtents(baseRaw, qemuimg.FormatRaw, baseExtents, "", ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -402,7 +401,7 @@ func TestExtentsBackingFile(t *testing.T) {
 			t.Fatal(err)
 		}
 		top := filepath.Join(tmpDir, "top.qcow2")
-		if err := createTestImageWithExtents(top, qemuimg.FormatQcow2, topExtents, baseQcow2, qemuimg.FormatQcow2); err != nil {
+		if err := testimage.CreateWithExtents(top, qemuimg.FormatQcow2, topExtents, baseQcow2, qemuimg.FormatQcow2); err != nil {
 			t.Fatal(err)
 		}
 		// When top and base are uncompressed, extents from to and based are merged.
@@ -430,7 +429,7 @@ func TestExtentsBackingFile(t *testing.T) {
 			t.Fatal(err)
 		}
 		top := filepath.Join(tmpDir, "top.qcow2")
-		if err := createTestImageWithExtents(top, qemuimg.FormatQcow2, topExtents, baseQcow2Zlib, qemuimg.FormatQcow2); err != nil {
+		if err := testimage.CreateWithExtents(top, qemuimg.FormatQcow2, topExtents, baseQcow2Zlib, qemuimg.FormatQcow2); err != nil {
 			t.Fatal(err)
 		}
 		// When base is compressed, extents from to and based cannot be merged since
@@ -483,11 +482,11 @@ func TestExtentsBackingFileShort(t *testing.T) {
 	}
 	tmpDir := t.TempDir()
 	base := filepath.Join(tmpDir, "base.qcow2")
-	if err := createTestImageWithExtents(base, qemuimg.FormatQcow2, baseExtents, "", ""); err != nil {
+	if err := testimage.CreateWithExtents(base, qemuimg.FormatQcow2, baseExtents, "", ""); err != nil {
 		t.Fatal(err)
 	}
 	top := filepath.Join(tmpDir, "top.qcow2")
-	if err := createTestImageWithExtents(top, qemuimg.FormatQcow2, topExtents, base, qemuimg.FormatQcow2); err != nil {
+	if err := testimage.CreateWithExtents(top, qemuimg.FormatQcow2, topExtents, base, qemuimg.FormatQcow2); err != nil {
 		t.Fatal(err)
 	}
 	actual, err := listExtents(top)
@@ -516,11 +515,11 @@ func TestExtentsBackingFileShortUnaligned(t *testing.T) {
 	}
 	tmpDir := t.TempDir()
 	base := filepath.Join(tmpDir, "base.raw")
-	if err := createTestImageWithExtents(base, qemuimg.FormatRaw, baseExtents, "", ""); err != nil {
+	if err := testimage.CreateWithExtents(base, qemuimg.FormatRaw, baseExtents, "", ""); err != nil {
 		t.Fatal(err)
 	}
 	top := filepath.Join(tmpDir, "top.qcow2")
-	if err := createTestImageWithExtents(top, qemuimg.FormatQcow2, topExtents, base, qemuimg.FormatRaw); err != nil {
+	if err := testimage.CreateWithExtents(top, qemuimg.FormatQcow2, topExtents, base, qemuimg.FormatRaw); err != nil {
 		t.Fatal(err)
 	}
 	actual, err := listExtents(top)
@@ -576,54 +575,12 @@ func listExtents(path string) ([]image.Extent, error) {
 	return extents, nil
 }
 
-// createTestImageWithExtents creates a n image with the allocation described
-// by extents.
-func createTestImageWithExtents(
-	path string,
-	format qemuimg.Format,
-	extents []image.Extent,
-	backingFile string,
-	backingFormat qemuimg.Format,
-) error {
-	lastExtent := extents[len(extents)-1]
-	size := lastExtent.Start + lastExtent.Length
-	if err := qemuimg.Create(path, format, size, backingFile, backingFormat); err != nil {
-		return err
-	}
-	for _, extent := range extents {
-		if !extent.Allocated {
-			continue
-		}
-		start := extent.Start
-		length := extent.Length
-		for length > 0 {
-			// qemu-io requires length < 2g.
-			n := length
-			if n >= 2*GiB {
-				n = 2*GiB - 64*KiB
-			}
-			if extent.Zero {
-				if err := qemuio.Zero(path, format, start, n); err != nil {
-					return err
-				}
-			} else {
-				if err := qemuio.Write(path, format, start, n, 0x55); err != nil {
-					return err
-				}
-			}
-			start += n
-			length -= n
-		}
-	}
-	return nil
-}
-
 // Benchmark completely empty sparse image (0% utilization).  This is the best
 // case when we don't have to read any cluster from storage.
 func Benchmark0p(b *testing.B) {
 	const size = 256 * MiB
 	base := filepath.Join(b.TempDir(), "image")
-	if err := createTestImage(base, size, 0.0); err != nil {
+	if err := testimage.Create(base, size, 0.0); err != nil {
 		b.Fatal(err)
 	}
 	b.Run("qcow2", func(b *testing.B) {
@@ -669,7 +626,7 @@ func Benchmark0p(b *testing.B) {
 func Benchmark50p(b *testing.B) {
 	const size = 256 * MiB
 	base := filepath.Join(b.TempDir(), "image")
-	if err := createTestImage(base, size, 0.5); err != nil {
+	if err := testimage.Create(base, size, 0.5); err != nil {
 		b.Fatal(err)
 	}
 	b.Run("qcow2", func(b *testing.B) {
@@ -716,7 +673,7 @@ func Benchmark50p(b *testing.B) {
 func Benchmark100p(b *testing.B) {
 	const size = 256 * MiB
 	base := filepath.Join(b.TempDir(), "image")
-	if err := createTestImage(base, size, 1.0); err != nil {
+	if err := testimage.Create(base, size, 1.0); err != nil {
 		b.Fatal(err)
 	}
 	b.Run("qcow2", func(b *testing.B) {
@@ -830,53 +787,4 @@ func resetBenchmark(b *testing.B, size int64) {
 	b.ResetTimer()
 	b.SetBytes(size)
 	b.ReportAllocs()
-}
-
-// createTestImage creates raw image with fake data that compresses like real
-// image data. Utilization deterimines the amount of data to allocate (0.0--1.0).
-func createTestImage(filename string, size int64, utilization float64) error {
-	if utilization < 0 || utilization > 1 {
-		return fmt.Errorf("utilization out of range (0.0-1.0): %f", utilization)
-	}
-
-	const chunkSize = 8 * MiB
-	dataSize := int64(float64(chunkSize) * utilization)
-
-	file, err := os.Create(filename)
-	if err != nil {
-		return err
-	}
-	defer file.Close() //nolint:errcheck
-	if err := file.Truncate(size); err != nil {
-		return err
-	}
-	if dataSize > 0 {
-		reader := &Generator{}
-		for offset := int64(0); offset < size; offset += chunkSize {
-			_, err := file.Seek(offset, io.SeekStart)
-			if err != nil {
-				return err
-			}
-			chunk := io.LimitReader(reader, dataSize)
-			if n, err := io.Copy(file, chunk); err != nil {
-				return err
-			} else if n != dataSize {
-				return fmt.Errorf("expected %d bytes, wrote %d bytes", dataSize, n)
-			}
-		}
-	}
-	return file.Close()
-}
-
-// Generator generates fake data that compresses like a real image data (30%).
-type Generator struct{}
-
-func (g *Generator) Read(b []byte) (int, error) {
-	for i := 0; i < len(b); i++ {
-		b[i] = byte(i & 0xff)
-	}
-	rand.Shuffle(len(b)/8*5, func(i, j int) {
-		b[i], b[j] = b[j], b[i]
-	})
-	return len(b), nil
 }

--- a/test/testimage/testimage.go
+++ b/test/testimage/testimage.go
@@ -1,0 +1,106 @@
+package testimage
+
+import (
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+
+	"github.com/lima-vm/go-qcow2reader/image"
+	"github.com/lima-vm/go-qcow2reader/test/qemuimg"
+	"github.com/lima-vm/go-qcow2reader/test/qemuio"
+	. "github.com/lima-vm/go-qcow2reader/test/units" //nolint:staticcheck
+)
+
+// CreateWithExtents creates an image with the allocation described by extents.
+func CreateWithExtents(
+	path string,
+	format qemuimg.Format,
+	extents []image.Extent,
+	backingFile string,
+	backingFormat qemuimg.Format,
+) error {
+	if len(extents) == 0 {
+		return fmt.Errorf("empty extents")
+	}
+	lastExtent := extents[len(extents)-1]
+	size := lastExtent.Start + lastExtent.Length
+	if err := qemuimg.Create(path, format, size, backingFile, backingFormat); err != nil {
+		return err
+	}
+	for _, extent := range extents {
+		if !extent.Allocated {
+			continue
+		}
+		start := extent.Start
+		length := extent.Length
+		for length > 0 {
+			// qemu-io requires length < 2g.
+			n := length
+			if n >= 2*GiB {
+				n = 2*GiB - 64*KiB
+			}
+			if extent.Zero {
+				if err := qemuio.Zero(path, format, start, n); err != nil {
+					return err
+				}
+			} else {
+				if err := qemuio.Write(path, format, start, n, 0x55); err != nil {
+					return err
+				}
+			}
+			start += n
+			length -= n
+		}
+	}
+	return nil
+}
+
+// Create creates a raw image with fake data that compresses like real image data.
+// Utilization determines the amount of data to allocate (0.0--1.0).
+func Create(filename string, size int64, utilization float64) error {
+	if utilization < 0 || utilization > 1 {
+		return fmt.Errorf("utilization out of range (0.0-1.0): %f", utilization)
+	}
+
+	const chunkSize = 8 * MiB
+	dataSize := int64(float64(chunkSize) * utilization)
+
+	file, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer file.Close() //nolint:errcheck
+	if err := file.Truncate(size); err != nil {
+		return err
+	}
+	if dataSize > 0 {
+		reader := &generator{}
+		for offset := int64(0); offset < size; offset += chunkSize {
+			_, err := file.Seek(offset, io.SeekStart)
+			if err != nil {
+				return err
+			}
+			chunk := io.LimitReader(reader, dataSize)
+			if n, err := io.Copy(file, chunk); err != nil {
+				return err
+			} else if n != dataSize {
+				return fmt.Errorf("expected %d bytes, wrote %d bytes", dataSize, n)
+			}
+		}
+	}
+	return file.Close()
+}
+
+// generator generates fake data that compresses like real image data (30%).
+type generator struct{}
+
+func (g *generator) Read(b []byte) (int, error) {
+	for i := 0; i < len(b); i++ {
+		b[i] = byte(i & 0xff)
+	}
+	rand.Shuffle(len(b)/8*5, func(i, j int) {
+		b[i], b[j] = b[j], b[i]
+	})
+	return len(b), nil
+}

--- a/test/units/units.go
+++ b/test/units/units.go
@@ -1,0 +1,7 @@
+package units
+
+const (
+	KiB = int64(1) << 10
+	MiB = int64(1) << 20
+	GiB = int64(1) << 30
+)


### PR DESCRIPTION
Add direct I/O support to the convert package for faster image conversion.
The write buffer is memory-aligned and the last write is padded to the
alignment boundary when needed. On platforms without O_DIRECT (macOS),
O_DSYNC is used to emulate direct I/O, same as QEMU.

- Refactor `Convert` into a `worker` struct for clarity and extensibility
- Add `Alignment` option for direct I/O buffer and write alignment
- Add `directio` package with platform-specific `Flag` and `DefaultAlignment`
- Add `-direct` flag to the example convert command
- Add buffered/direct benchmarks, extract shared test helpers

## Results

Tested with Ubuntu 26.04 qcow2 image.

### macOS (O_DSYNC), uncompressed

| Command                          | Time (ms) | vs baseline |
|----------------------------------|-----------|-------------|
| go-qcow2reader convert          |      1049 |    baseline |
| go-qcow2reader convert -direct  |       493 |       2.13x |
| qemu-img convert                |      1239 |       0.85x |
| qemu-img convert -t none -W     |       567 |       1.85x |

### macOS (O_DSYNC), compressed

| Command                          | Time (ms) | vs baseline |
|----------------------------------|-----------|-------------|
| go-qcow2reader convert          |      2983 |    baseline |
| go-qcow2reader convert -direct  |      2329 |       1.28x |
| qemu-img convert                |      2490 |       1.20x |
| qemu-img convert -t none -W     |      1418 |       2.10x |

### Linux/Fedora 43 VM (O_DIRECT), uncompressed

| Command                          | Time (ms) | vs baseline |
|----------------------------------|-----------|-------------|
| go-qcow2reader convert          |      2047 |    baseline |
| go-qcow2reader convert -direct  |      1302 |       1.57x |
| qemu-img convert                |      1915 |       1.07x |
| qemu-img convert -t none -W     |      1328 |       1.54x |

### Linux/Fedora 43 VM (O_DIRECT), compressed

| Command                          | Time (ms) | vs baseline |
|----------------------------------|-----------|-------------|
| go-qcow2reader convert          |      5346 |    baseline |
| go-qcow2reader convert -direct  |      4426 |       1.21x |
| qemu-img convert                |      2119 |       2.52x |
| qemu-img convert -t none -W     |      2558 |       2.09x |

With uncompressed images, -direct matches or beats qemu-img -t none -W
on both platforms. With compressed images, qemu-img is faster due to its
native zlib implementation, but -direct still reduces wall time by
1.2-1.3x by cutting kernel overhead.