### PR TITLE
Support listing internal snapshots

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,16 @@ jobs:
           qemu-img convert -f qcow2 -O qcow2 -o compression_type=zstd debian-11-genericcloud-amd64-20230501-1367.qcow2 debian-11-genericcloud-amd64-20230501-1367.zstd.qcow2
           # Convert to ext_l2
           qemu-img convert -f qcow2 -O qcow2 -o extended_l2=on debian-11-genericcloud-amd64-20230501-1367.qcow2 debian-11-genericcloud-amd64-20230501-1367.ext_l2.qcow2
+          # Create an image with internal snapshots.
+          # Write different data before, between, and after the snapshots, so
+          # that every snapshot captures a distinct disk state and the writes
+          # after a snapshot exercise copy-on-write in the active layer.
+          cp debian-11-genericcloud-amd64-20230501-1367.qcow2 debian-11-genericcloud-amd64-20230501-1367.snapshot.qcow2
+          qemu-io -f qcow2 -c "write -P 0xaa 0 8M" debian-11-genericcloud-amd64-20230501-1367.snapshot.qcow2
+          qemu-img snapshot -c snap1 debian-11-genericcloud-amd64-20230501-1367.snapshot.qcow2
+          qemu-io -f qcow2 -c "write -P 0xbb 4M 8M" debian-11-genericcloud-amd64-20230501-1367.snapshot.qcow2
+          qemu-img snapshot -c "second snapshot" debian-11-genericcloud-amd64-20230501-1367.snapshot.qcow2
+          qemu-io -f qcow2 -c "write -P 0xcc 1G 16M" debian-11-genericcloud-amd64-20230501-1367.snapshot.qcow2
       - name: Prepare test-images
         run: cp -a test-images-ro test-images
       - name: "Test debian-11-genericcloud-amd64-20230501-1367.qcow2"
@@ -58,6 +68,10 @@ jobs:
         run: hack/compare-with-qemu-img.sh test-images/debian-11-genericcloud-amd64-20230501-1367.zstd.qcow2
       - name: "Test debian-11-genericcloud-amd64-20230501-1367.ext_l2.qcow2"
         run: hack/compare-with-qemu-img.sh test-images/debian-11-genericcloud-amd64-20230501-1367.ext_l2.qcow2
+      - name: "Test debian-11-genericcloud-amd64-20230501-1367.snapshot.qcow2 (internal snapshots)"
+        run: |
+          hack/compare-snapshots-with-qemu-img.sh test-images/debian-11-genericcloud-amd64-20230501-1367.snapshot.qcow2
+          hack/compare-with-qemu-img.sh test-images/debian-11-genericcloud-amd64-20230501-1367.snapshot.qcow2
 
   macos-unit-tests:
     runs-on: macos-latest

--- a/cmd/go-qcow2reader-example/main.go
+++ b/cmd/go-qcow2reader-example/main.go
@@ -43,6 +43,7 @@ Available commands:
   read		read image data and print to stdout
   convert	convert image to raw format
   map		print image extents
+  snapshot	list internal snapshots
 `
 	fmt.Fprintf(os.Stderr, usage, os.Args[0])
 	os.Exit(1)
@@ -74,6 +75,8 @@ func main() {
 		err = cmdConvert(args)
 	case "map":
 		err = cmdMap(args)
+	case "snapshot":
+		err = cmdSnapshot(args)
 	default:
 		usage()
 	}

--- a/cmd/go-qcow2reader-example/snapshot.go
+++ b/cmd/go-qcow2reader-example/snapshot.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/lima-vm/go-qcow2reader"
+	"github.com/lima-vm/go-qcow2reader/image"
+	"github.com/lima-vm/go-qcow2reader/log"
+)
+
+func cmdSnapshot(args []string) error {
+	var (
+		// Required
+		filename string
+
+		// Options
+		debug bool
+	)
+
+	fs := flag.NewFlagSet("snapshot", flag.ExitOnError)
+	fs.Usage = func() {
+		fmt.Fprintf(fs.Output(), "Usage: %s snapshot [OPTIONS...] FILE\n", os.Args[0])
+		fs.PrintDefaults()
+	}
+	fs.BoolVar(&debug, "debug", false, "enable printing debug messages")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if debug {
+		log.SetDebugFunc(logDebug)
+	}
+
+	switch len(fs.Args()) {
+	case 0:
+		return errors.New("no file was specified")
+	case 1:
+		filename = fs.Arg(0)
+	default:
+		return errors.New("too many files were specified")
+	}
+
+	f, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	img, err := qcow2reader.Open(f)
+	if err != nil {
+		return err
+	}
+	defer img.Close()
+
+	snapshotReader, ok := img.(image.SnapshotReader)
+	if !ok {
+		return fmt.Errorf("image type %q does not support snapshots", img.Type())
+	}
+	snapshots, err := snapshotReader.Snapshots()
+	if err != nil {
+		return err
+	}
+
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "    ")
+	return encoder.Encode(snapshots)
+}

--- a/hack/compare-snapshots-with-qemu-img.sh
+++ b/hack/compare-snapshots-with-qemu-img.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -eu -o pipefail
+if [ "$#" -ne 1 ]; then
+	echo >&2 "Usage: $0 FILE"
+	exit 1
+fi
+
+name_qcow2="$1"
+
+echo "Input file: ${name_qcow2}"
+set -x
+go-qcow2reader-example snapshot "${name_qcow2}"
+set +x
+
+# Canonicalize qemu-img's SnapshotInfo entries.
+# The qcow2-specific fields ("vm-state-size", "vm-clock-sec", "vm-clock-nsec",
+# "icount") are not printed by `go-qcow2reader-example snapshot --list`,
+# so they are ignored.
+expected="$(qemu-img info --output=json "${name_qcow2}" |
+	jq -S '[.snapshots[]? | {
+		id,
+		name,
+		date_sec: ."date-sec",
+		date_nsec: ."date-nsec"
+	}]')"
+
+if ! echo "${expected}" | jq -e 'length > 0' >/dev/null; then
+	echo >&2 "Expected at least one snapshot in ${name_qcow2}"
+	exit 1
+fi
+
+# Canonicalize go-qcow2reader's snapshot entries.
+# "created_at" (RFC 3339, UTC) is split into seconds and nanoseconds.
+got="$(go-qcow2reader-example snapshot "${name_qcow2}" |
+	jq -S '[.[]? | (.created_at | capture("^(?<d>[^.]+?)(\\.(?<f>[0-9]+))?Z$")) as $t | {
+		id,
+		name,
+		date_sec: ($t.d + "Z" | fromdateiso8601),
+		date_nsec: ((($t.f // "") + "000000000")[0:9] | tonumber)
+	}]')"
+
+echo "Expected: ${expected}"
+echo "Got: ${got}"
+if [ "${expected}" = "${got}" ]; then
+	echo "OK"
+else
+	echo "FAIL"
+	exit 1
+fi

--- a/image/image.go
+++ b/image/image.go
@@ -3,6 +3,7 @@ package image
 import (
 	"errors"
 	"io"
+	"time"
 )
 
 // Type must be a "Backing file format name string" that appears in QCOW2.
@@ -23,6 +24,24 @@ type Extent struct {
 	Zero bool `json:"zero"`
 	// Set if this extent is compressed.
 	Compressed bool `json:"compressed"`
+}
+
+// Snapshot describes an internal snapshot stored in the image.
+type Snapshot struct {
+	// ID is the unique ID of the snapshot.
+	ID string `json:"id"`
+	// Name is the human-readable name of the snapshot.
+	Name string `json:"name"`
+	// CreatedAt is the time at which the snapshot was taken.
+	// Nil if unknown.
+	CreatedAt *time.Time `json:"created_at,omitempty"`
+}
+
+// SnapshotReader is optionally implemented by an [Image] that supports
+// reading internal snapshots.
+type SnapshotReader interface {
+	// Snapshots returns the internal snapshots stored in the image.
+	Snapshots() ([]Snapshot, error)
 }
 
 // Image implements [io.ReaderAt] and [io.Closer].

--- a/image/qcow2/qcow2.go
+++ b/image/qcow2/qcow2.go
@@ -534,7 +534,9 @@ type Qcow2 struct {
 	ra                  io.ReaderAt
 	*Header             `json:"header"`
 	HeaderExtensions    []HeaderExtension `json:"header_extensions"`
+	SnapshotEntries     []Snapshot        `json:"snapshots,omitempty"`
 	errUnreadable       error
+	errSnapshots        error
 	clusterSize         int
 	l2Entries           int
 	l1Table             []l1TableEntry
@@ -583,6 +585,14 @@ func Open(ra io.ReaderAt, openWithType image.OpenWithType) (*Qcow2, error) {
 					break
 				}
 				img.BackingFileFormat = image.Type(backingFileFormat)
+			}
+		}
+
+		// Load snapshots
+		if img.NbSnapshots != 0 {
+			img.SnapshotEntries, img.errSnapshots = readSnapshots(ra, img.SnapshotsOffset, img.NbSnapshots)
+			if img.errSnapshots != nil {
+				log.Warnf("Failed to read snapshots: %v", img.errSnapshots)
 			}
 		}
 
@@ -688,6 +698,20 @@ func (img *Qcow2) Size() int64 {
 
 func (img *Qcow2) Readable() error {
 	return img.errUnreadable
+}
+
+// Snapshots implements [image.SnapshotReader].
+// The result lacks qcow2-specific information; use the SnapshotEntries
+// field of [Qcow2] to retrieve it.
+func (img *Qcow2) Snapshots() ([]image.Snapshot, error) {
+	if img.errSnapshots != nil {
+		return nil, img.errSnapshots
+	}
+	snapshots := make([]image.Snapshot, len(img.SnapshotEntries))
+	for i, s := range img.SnapshotEntries {
+		snapshots[i] = s.Snapshot
+	}
+	return snapshots, nil
 }
 
 func (img *Qcow2) extendedL2() bool {

--- a/image/qcow2/snapshot.go
+++ b/image/qcow2/snapshot.go
@@ -1,0 +1,113 @@
+package qcow2
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/lima-vm/go-qcow2reader/align"
+	"github.com/lima-vm/go-qcow2reader/image"
+)
+
+var _ image.SnapshotReader = (*Qcow2)(nil)
+
+// Snapshot wraps [image.Snapshot] with qcow2-specific fields.
+type Snapshot struct {
+	image.Snapshot
+	// VMStateSize is the size of the VM state in bytes. 0 if no VM state is saved.
+	VMStateSize uint64 `json:"vm_state_size"`
+	// VMClock is the time that the guest was running until the snapshot was taken.
+	VMClock time.Duration `json:"vm_clock"`
+}
+
+// maxSnapshots is the maximum number of snapshots.
+// Corresponds to QCOW_MAX_SNAPSHOTS in QEMU.
+const maxSnapshots = 65536
+
+// maxSnapshotExtraData is the maximum size of extra data in a snapshot table
+// entry. Corresponds to QCOW_MAX_SNAPSHOT_EXTRA_DATA in QEMU.
+const maxSnapshotExtraData = 1024
+
+// snapshotTableEntry is the static part of an entry of the snapshot table.
+// The entry is followed by the extra data, the unique ID string, the name,
+// and padding to the next multiple of 8 bytes.
+type snapshotTableEntry struct {
+	// L1TableOffset is the offset into the image file at which the L1 table
+	// for the snapshot starts.
+	L1TableOffset uint64
+	// L1Size is the number of entries in the L1 table of the snapshot.
+	L1Size uint32
+	// IDSize is the length of the unique ID string describing the snapshot.
+	IDSize uint16
+	// NameSize is the length of the name of the snapshot.
+	NameSize uint16
+	// DateSec is the time at which the snapshot was taken in seconds since the Epoch.
+	DateSec uint32
+	// DateNsec is the subsecond part of the time at which the snapshot was taken.
+	DateNsec uint32
+	// VMClockNsec is the time that the guest was running until the snapshot
+	// was taken in nanoseconds.
+	VMClockNsec uint64
+	// VMStateSize is the size of the VM state in bytes. 0 if no VM state is saved.
+	// Superseded by the 64-bit field in the extra data, if present.
+	VMStateSize uint32
+	// ExtraDataSize is the size of extra data in the table entry.
+	ExtraDataSize uint32
+}
+
+// readSnapshots reads the snapshot table.
+func readSnapshots(ra io.ReaderAt, offset uint64, entries uint32) ([]Snapshot, error) {
+	if offset == 0 {
+		return nil, errors.New("invalid snapshot table offset: 0")
+	}
+	if entries > maxSnapshots {
+		return nil, fmt.Errorf("too many snapshots (%d entries > %d entries)", entries, maxSnapshots)
+	}
+	r := io.NewSectionReader(ra, int64(offset), -1)
+	snapshots := make([]Snapshot, entries)
+	for i := range snapshots {
+		var ent snapshotTableEntry
+		if err := binary.Read(r, binary.BigEndian, &ent); err != nil {
+			return nil, fmt.Errorf("failed to read snapshot %d: %w", i, err)
+		}
+		if ent.ExtraDataSize > maxSnapshotExtraData {
+			return nil, fmt.Errorf("failed to read snapshot %d: too much extra data (%d bytes > %d bytes)",
+				i, ent.ExtraDataSize, maxSnapshotExtraData)
+		}
+		buf := make([]byte, int(ent.ExtraDataSize)+int(ent.IDSize)+int(ent.NameSize))
+		if _, err := io.ReadFull(r, buf); err != nil {
+			return nil, fmt.Errorf("failed to read snapshot %d: %w", i, err)
+		}
+		extra := buf[:ent.ExtraDataSize]
+		id := buf[ent.ExtraDataSize : ent.ExtraDataSize+uint32(ent.IDSize)]
+		name := buf[ent.ExtraDataSize+uint32(ent.IDSize):]
+		createdAt := time.Unix(int64(ent.DateSec), int64(ent.DateNsec)).UTC()
+		sn := Snapshot{
+			Snapshot: image.Snapshot{
+				ID:        string(id),
+				Name:      string(name),
+				CreatedAt: &createdAt,
+			},
+			VMStateSize: uint64(ent.VMStateSize),
+			VMClock:     time.Duration(ent.VMClockNsec),
+		}
+		if len(extra) >= 8 {
+			sn.VMStateSize = binary.BigEndian.Uint64(extra[0:8])
+		}
+		// extra[8:16] (virtual disk size of the snapshot) and extra[16:24]
+		// (icount value) are not exposed in [Snapshot].
+		snapshots[i] = sn
+
+		// The snapshot table entry is padded to the next multiple of 8 bytes.
+		// The static part is already a multiple of 8 bytes, so only the
+		// variable part matters.
+		if pad := align.Up(len(buf), 8) - len(buf); pad > 0 {
+			if _, err := r.Seek(int64(pad), io.SeekCurrent); err != nil {
+				return nil, fmt.Errorf("failed to read snapshot %d: %w", i, err)
+			}
+		}
+	}
+	return snapshots, nil
+}

--- a/image/qcow2/snapshot_test.go
+++ b/image/qcow2/snapshot_test.go
@@ -1,0 +1,122 @@
+package qcow2
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	imagepkg "github.com/lima-vm/go-qcow2reader/image"
+)
+
+func TestReadSnapshots(t *testing.T) {
+	var table bytes.Buffer
+	writeSnapshotTableEntry(t, &table, snapshotTableEntry{
+		L1TableOffset: 65536,
+		L1Size:        1,
+		DateSec:       1234,
+		DateNsec:      5678,
+		VMClockNsec:   12_345_678_901,
+		VMStateSize:   42,
+	}, nil, "1", "first")
+
+	extra := make([]byte, 24)
+	binary.BigEndian.PutUint64(extra[0:8], 1<<32+42)
+	binary.BigEndian.PutUint64(extra[8:16], 8<<30)
+	binary.BigEndian.PutUint64(extra[16:24], 99)
+	writeSnapshotTableEntry(t, &table, snapshotTableEntry{
+		L1TableOffset: 131072,
+		L1Size:        2,
+		DateSec:       2345,
+		DateNsec:      6789,
+		VMClockNsec:   98_765_432_109,
+		VMStateSize:   1, // Superseded by the 64-bit field in extra data.
+	}, extra, "snapshot-id", "second snapshot")
+
+	const offset = 4096
+	image := append(make([]byte, offset), table.Bytes()...)
+	snapshots, err := readSnapshots(bytes.NewReader(image), offset, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	createdAt1 := time.Unix(1234, 5678).UTC()
+	createdAt2 := time.Unix(2345, 6789).UTC()
+	want := []Snapshot{
+		{
+			Snapshot: imagepkg.Snapshot{
+				ID: "1", Name: "first",
+				CreatedAt: &createdAt1,
+			},
+			VMStateSize: 42,
+			VMClock:     12_345_678_901,
+		},
+		{
+			Snapshot: imagepkg.Snapshot{
+				ID: "snapshot-id", Name: "second snapshot",
+				CreatedAt: &createdAt2,
+			},
+			VMStateSize: 1<<32 + 42,
+			VMClock:     98_765_432_109,
+		},
+	}
+	if !reflect.DeepEqual(snapshots, want) {
+		t.Fatalf("expected %#v, got %#v", want, snapshots)
+	}
+}
+
+func TestReadSnapshotsIgnoresQCOW2SpecificICount(t *testing.T) {
+	var table bytes.Buffer
+	extra := make([]byte, 24)
+	binary.BigEndian.PutUint64(extra[16:24], math.MaxUint64)
+	writeSnapshotTableEntry(t, &table, snapshotTableEntry{}, extra, "id", "name")
+
+	// Offset zero is deliberately invalid, so prefix the table with one byte.
+	image := append([]byte{0}, table.Bytes()...)
+	snapshots, err := readSnapshots(bytes.NewReader(image), 1, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshots) != 1 {
+		t.Fatalf("expected one snapshot, got %d", len(snapshots))
+	}
+}
+
+func TestReadSnapshotsErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		offset  uint64
+		entries uint32
+		want    string
+	}{
+		{name: "zero offset", offset: 0, entries: 1, want: "invalid snapshot table offset"},
+		{name: "too many", offset: 1, entries: maxSnapshots + 1, want: "too many snapshots"},
+		{name: "truncated", offset: 1, entries: 1, want: "failed to read snapshot"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := readSnapshots(bytes.NewReader(nil), tt.offset, tt.entries)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("expected error containing %q, got %v", tt.want, err)
+			}
+		})
+	}
+}
+
+func writeSnapshotTableEntry(t *testing.T, buf *bytes.Buffer, ent snapshotTableEntry, extra []byte, id, name string) {
+	t.Helper()
+	ent.ExtraDataSize = uint32(len(extra))
+	ent.IDSize = uint16(len(id))
+	ent.NameSize = uint16(len(name))
+	if err := binary.Write(buf, binary.BigEndian, &ent); err != nil {
+		t.Fatal(err)
+	}
+	buf.Write(extra)
+	buf.WriteString(id)
+	buf.WriteString(name)
+	for buf.Len()%8 != 0 {
+		buf.WriteByte(0)
+	}
+}


### PR DESCRIPTION
<!-- Please read our contribution rules before submitting:

- Pull requests guide: https://lima-vm.io/docs/community/contributing/#sending-pull-requests
- AI usage policy: https://lima-vm.io/docs/community/contributing/#ai-contribution-rules

-->

## What This PR Changes

<!-- Explain the single problem this PR fixes, in your own words. -->
Equivalent of `qemu-img snapshot --list`.

- The image package provides the generic Snapshot struct and the SnapshotReader interface.
- The image/qcow2 package parses the snapshot table and exposes it as Qcow2.Snapshots, wrapping the generic struct with the qcow2-specific fields (VM state size, VM clock).
- go-qcow2reader-example gains a `snapshot` subcommand using the generic interface.
- CI creates an image with internal snapshots (with writes in between, to exercise copy-on-write) and compares the listing and the data reads against qemu-img.



## Linked Issue (Required in most cases)

<!-- Link the issue here. If your issue is not approved by a maintainer, don't expect your PR to be merged. -->

Closes #75

## How I Tested This

CI

## AI Usage

<!-- If you used AI tools, say which tool and how you used it. For example, `Assisted-by: AI_AGENT_NAME:VERSION [TOOL]` or `Co-Authored-By`-->
Assisted-by: Claude Fable 5 <noreply@anthropic.com>
